### PR TITLE
Add photo mode and screenshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ settings menu and persist via ``config.json``. A configurable FPS cap limits the
 main loop and an optional overlay displays frame time, draw calls and the time
 spent on post-processing.
 
+## Photo Mode & Screenshots
+
+Press **F10** in-game to pause time and enter a free camera mode. The mouse and
+W/A/S/D keys pan the view while **H** toggles the UI overlay. Capture the
+current frame with **F12** – images are stored as PNG files under
+`~/.oko_zombie/screenshots/` and include the session's seed in their filename.
+When running the demo build a semi-transparent watermark is added
+automatically.
+
 ## Telemetry & Crash Reports (Opt-in)
 
 The game can optionally send anonymous telemetry events and crash reports to a

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -123,4 +123,5 @@
   ,"theme_apocalypse": "Apocalypse"
   ,"show_minimap": "Show Minimap"
   ,"minimap_size": "Minimap Size"
+  ,"photo_hint": "F10 - Photo Mode"
 }

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -123,4 +123,5 @@
   ,"theme_apocalypse": "Апокалипсис"
   ,"show_minimap": "Мини-карта"
   ,"minimap_size": "Размер мини-карты"
+  ,"photo_hint": "F10 — Фото режим"
 }

--- a/src/client/app.py
+++ b/src/client/app.py
@@ -12,6 +12,7 @@ from . import input as cinput
 from .gfx.anim import FadeTransition
 from . import sfx
 from .scene_replay import ReplayScene  # imported for routing; used by menu
+from .scene_photo import PhotoScene  # imported for hotkey access
 from .gfx import postfx
 from .ui import theme as ui_theme
 

--- a/src/client/gfx/postfx.py
+++ b/src/client/gfx/postfx.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Simple post processing effects operating on :mod:`pygame` surfaces."""
 
 from typing import Iterable
+from pathlib import Path
 import pygame
 import numpy as np
 
@@ -109,3 +110,32 @@ def count_enabled(cfg) -> int:
         if cfg.get(key):
             count += 1
     return count
+
+
+def export_frame(
+    surface: pygame.Surface,
+    path: Path,
+    cfg,
+    watermark: pygame.Surface | None = None,
+) -> None:
+    """Apply post effects and save ``surface`` to ``path``.
+
+    Parameters
+    ----------
+    surface:
+        The surface representing the raw frame.
+    path:
+        Target file path where the PNG will be written.
+    cfg:
+        Configuration dictionary controlling enabled post effects.
+    watermark:
+        Optional surface blended in the bottom right corner before saving,
+        used for the demo watermark.
+    """
+
+    frame = apply_chain(surface, cfg)
+    if watermark:
+        x = frame.get_width() - watermark.get_width() - 8
+        y = frame.get_height() - watermark.get_height() - 8
+        frame.blit(watermark, (x, y))
+    pygame.image.save(frame, str(path))

--- a/src/client/scene_game.py
+++ b/src/client/scene_game.py
@@ -26,6 +26,7 @@ from .net_client import NetClient
 from gamecore import board as gboard
 from gamecore import rules, saveio, config as gconfig, achievements
 from gamecore import balance as gbalance, events as gevents, scenario as gscenario, i18n
+from gamecore.i18n import gettext as _
 from replay.recorder import Recorder
 
 try:  # pragma: no cover - optional dependency
@@ -237,6 +238,11 @@ class GameScene(Scene):
             if event.key == pygame.K_ESCAPE:
                 self._open_pause_menu()
                 return
+            if event.key == pygame.K_F10:
+                from .scene_photo import PhotoScene
+
+                self.next_scene = PhotoScene(self.app, self)
+                return
             action = self.input.action_from_key(event.key)
             if action == "pause":
                 self._open_pause_menu()
@@ -366,7 +372,7 @@ class GameScene(Scene):
             self.event_popup.update(dt)
         self.toasts.update(dt)
 
-    def draw(self, surface: pygame.Surface) -> None:
+    def draw(self, surface: pygame.Surface, ui: bool = True) -> None:
         w, h = surface.get_size()
         layers = {layer: pygame.Surface((w, h), pygame.SRCALPHA) for layer in Layer}
         layers[Layer.BACKGROUND].fill((0, 0, 0))
@@ -384,16 +390,19 @@ class GameScene(Scene):
         self._apply_lighting(surface)
         if self.weather:
             self.weather.draw(surface, (self.camera.x, self.camera.y))
-        log_rect = pygame.Rect(w - 200, 0, 200, h)
-        self.log.draw(surface, log_rect)
-        self.status.draw(surface, self.state)
-        if self.event_popup:
-            self.event_popup.draw(surface)
-        if self.paused and self.pause_menu:
-            self.pause_menu.draw(surface)
-        self._draw_minimap(surface)
-        self.toasts.draw(surface)
-        hover_hints.draw(surface)
+        if ui:
+            log_rect = pygame.Rect(w - 200, 0, 200, h)
+            self.log.draw(surface, log_rect)
+            self.status.draw(surface, self.state)
+            if self.event_popup:
+                self.event_popup.draw(surface)
+            if self.paused and self.pause_menu:
+                self.pause_menu.draw(surface)
+            self._draw_minimap(surface)
+            self.toasts.draw(surface)
+            hover_hints.draw(surface)
+            hint = self.app.font.render(_("photo_hint"), True, (255, 255, 255))
+            surface.blit(hint, (8, h - hint.get_height() - 8))
 
     def _build_minimap(self) -> None:
         board = self.state.board

--- a/src/client/scene_photo.py
+++ b/src/client/scene_photo.py
@@ -1,0 +1,76 @@
+"""Photo mode scene providing a free camera and screenshot support."""
+from __future__ import annotations
+
+import pygame
+
+from .app import Scene
+from .gfx.camera import SmoothCamera
+from .gfx import postfx
+from gamecore import config as gconfig, rules
+
+
+class PhotoScene(Scene):
+    """Frozen snapshot of :class:`~client.scene_game.GameScene` with controls."""
+
+    def __init__(self, app, base_scene) -> None:
+        super().__init__(app)
+        self.base = base_scene
+        self.camera: SmoothCamera = base_scene.camera
+        self.dragging = False
+        self.hide_ui = False
+
+    # ------------------------------------------------------------------
+    # event handling
+    # ------------------------------------------------------------------
+    def handle_event(self, event: pygame.event.Event) -> None:  # pragma: no cover - GUI only
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_F10:
+                self.next_scene = self.base
+                return
+            if event.key == pygame.K_h:
+                self.hide_ui = not self.hide_ui
+                return
+            if event.key == pygame.K_F12:
+                self._capture()
+                return
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self.dragging = True
+        elif event.type == pygame.MOUSEBUTTONUP and event.button == 1:
+            self.dragging = False
+        elif event.type == pygame.MOUSEMOTION and self.dragging:
+            dx, dy = event.rel
+            self.camera.target_x -= dx / self.camera.zoom
+            self.camera.target_y -= dy / self.camera.zoom
+        elif event.type == pygame.MOUSEWHEEL:
+            self.camera.zoom_at(event.y, event.pos)
+
+    # ------------------------------------------------------------------
+    def _capture(self) -> None:  # pragma: no cover - GUI only
+        """Save current frame as a screenshot."""
+
+        path = gconfig.screenshot_path(getattr(rules.RNG, "_seed", 0))
+        surface = self.app.screen.copy()
+        watermark = None
+        if rules.DEMO_MODE and rules.DEMO_WATERMARK:
+            font = pygame.font.SysFont(None, 48)
+            watermark = font.render(rules.DEMO_WATERMARK, True, (255, 255, 255))
+            watermark.set_alpha(128)
+        postfx.export_frame(surface, path, self.app.cfg, watermark)
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:  # pragma: no cover - GUI only
+        keys = pygame.key.get_pressed()
+        speed = 300.0 * dt / self.camera.zoom
+        if keys[pygame.K_w]:
+            self.camera.target_y -= speed
+        if keys[pygame.K_s]:
+            self.camera.target_y += speed
+        if keys[pygame.K_a]:
+            self.camera.target_x -= speed
+        if keys[pygame.K_d]:
+            self.camera.target_x += speed
+        self.camera.update(dt)
+
+    # ------------------------------------------------------------------
+    def draw(self, surface: pygame.Surface) -> None:  # pragma: no cover - GUI only
+        self.base.draw(surface, ui=not self.hide_ui)

--- a/src/gamecore/config.py
+++ b/src/gamecore/config.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import uuid
+import time
 from pathlib import Path
 from typing import Any, Dict
 
 CONFIG_DIR = Path.home() / ".oko_zombie"
 SAVE_DIR = CONFIG_DIR / "saves"
 REPLAY_DIR = CONFIG_DIR / "replays"
+SCREENSHOT_DIR = CONFIG_DIR / "screenshots"
 CONFIG_FILE = CONFIG_DIR / "config.json"
 
 DEFAULT_CONFIG: Dict[str, Any] = {
@@ -49,6 +51,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
 def _ensure_dirs() -> None:
     SAVE_DIR.mkdir(parents=True, exist_ok=True)
     REPLAY_DIR.mkdir(parents=True, exist_ok=True)
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def load_config() -> Dict[str, Any]:
@@ -101,3 +104,21 @@ def replay_dir() -> Path:
 
     _ensure_dirs()
     return REPLAY_DIR
+
+
+def screenshot_dir() -> Path:
+    """Directory containing captured screenshots."""
+
+    _ensure_dirs()
+    return SCREENSHOT_DIR
+
+
+def screenshot_path(seed: int) -> Path:
+    """Return a unique path for a screenshot.
+
+    Filenames are composed of the current date/time and the supplied ``seed``
+    to make runs with different seeds easier to identify.
+    """
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    return screenshot_dir() / f"{timestamp}_{seed}.png"

--- a/src/gamecore/rules.py
+++ b/src/gamecore/rules.py
@@ -14,6 +14,8 @@ MAX_TURNS = 100
 # Flag toggled when the game runs in limited demo mode.  Set by the client
 # when ``--demo`` is passed on the command line.
 DEMO_MODE = False
+# Optional watermark text used on screenshots when in demo mode.
+DEMO_WATERMARK = "DEMO"
 
 # Maximum number of in-game days/turns allowed in the demo.
 DEMO_MAX_DAYS = 3


### PR DESCRIPTION
## Summary
- Add dedicated Photo Mode scene with free camera, UI toggle and screenshot capture
- Add screenshot utilities and demo watermark support
- Expose screenshot directory and filename helper in config
- Show Photo Mode hint and enable F10 toggle in gameplay

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b37a3f5fc8329b0e33372640be0b8