### PR TITLE
Simplify net protocol and extend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ python -m scripts.run_cli --seed 123
 python -m scripts.run_gui
 ```
 
+## Multiplayer
+
+The project supports both local and online multiplayer.  Local co-op allows
+2–4 players to take alternating turns on the same machine and works entirely
+offline.  Online games use a small asyncio based websocket server which
+broadcasts authoritative state updates to connected clients.  All random number
+generation happens on the server to keep sessions deterministic while the
+pygame client simply renders the received state.
+
 ## Balance
 
 Core combat and spawn values are configured in `data/balance.json`. The loader

--- a/src/net/protocol.py
+++ b/src/net/protocol.py
@@ -12,11 +12,7 @@ class MessageType(str, Enum):
     """Supported message types."""
 
     HELLO = "HELLO"
-    LOBBY_CREATE = "LOBBY_CREATE"
-    LOBBY_JOIN = "LOBBY_JOIN"
-    LOBBY_LIST = "LOBBY_LIST"
-    READY = "READY"
-    START = "START"
+    LOBBY = "LOBBY"
     ACTION = "ACTION"
     STATE = "STATE"
     PING = "PING"

--- a/tests/test_net_protocol.py
+++ b/tests/test_net_protocol.py
@@ -6,12 +6,17 @@ from net.protocol import (
 )
 
 
-def test_round_trip() -> None:
-    msg = {"t": MessageType.PING.value}
+def _round_trip(msg_type: MessageType) -> None:
+    msg = {"t": msg_type.value}
     encoded = encode_message(msg)
     decoded = decode_message(encoded)
-    assert decoded["t"] == MessageType.PING.value
+    assert decoded["t"] == msg_type.value
     assert decoded["v"] == PROTOCOL_VERSION
+
+
+def test_round_trip_all_types() -> None:
+    for mt in MessageType:
+        _round_trip(mt)
 
 
 def test_invalid_type() -> None:


### PR DESCRIPTION
## Summary
- Collapse lobby messages into single LOBBY type and simplify protocol enum
- Test round-trip encoding/decoding for all protocol message types
- Document multiplayer modes and deterministic server RNG in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b47a5dce483299abdd63670965aa9