### PR TITLE
Add PyInstaller build scripts and dynamic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@
 pip install -r requirements.txt
 ```
 
+## Local build: PyInstaller & Versioning
+
+The project version is derived from git tags via `tools/versioning.py`. When no tags are present it falls back to `0.0.0+dev`.
+
+To create a standalone executable for the current platform:
+
+```bash
+python tools/build_pyinstaller.py --target linux
+```
+
+Replace `linux` with `win` or `mac` as needed. The binary will be placed in `dist/<platform>/`. To assemble a distribution staging area:
+
+```bash
+python tools/package_release.py --target linux
+```
+
+This gathers the built binary and runtime resources in `build/staging/<platform>/`.
+
+
 ## CLI
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [project]
 name = "gamecore"
-version = "0.1.0"
+dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = []
+
+[tool.setuptools.dynamic]
+version = { attr = "tools.versioning.__version__" }
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/tools/build_pyinstaller.py
+++ b/tools/build_pyinstaller.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+RUNTIME_DIRS = ["data", "data/locales"]
+RUNTIME_FILES = ["board_layout.json", "decks.json", "textures.json"]
+ICON_MAP = {"win": "data/icon.ico", "mac": "data/icon.icns", "linux": "data/icon.png"}
+
+
+def build(target: str) -> None:
+    dist_dir = Path("dist") / target
+    dist_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "pyinstaller",
+        "--noconfirm",
+        "--onefile",
+        f"--distpath={dist_dir}",
+        "scripts/run_gui.py",
+    ]
+
+    for directory in RUNTIME_DIRS:
+        p = Path(directory)
+        if p.exists():
+            cmd.extend(["--add-data", f"{p}{os.pathsep}{p}"])
+
+    for file in RUNTIME_FILES:
+        p = Path(file)
+        if p.exists():
+            cmd.extend(["--add-data", f"{p}{os.pathsep}{p}"])
+
+    icon = Path(ICON_MAP.get(target, ""))
+    if icon.is_file():
+        cmd.append(f"--icon={icon}")
+
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build the GUI with PyInstaller")
+    parser.add_argument("--target", choices=["win", "mac", "linux"], required=True)
+    args = parser.parse_args()
+    build(args.target)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/package_release.py
+++ b/tools/package_release.py
@@ -1,0 +1,40 @@
+import argparse
+import shutil
+import stat
+from pathlib import Path
+
+EXCLUDE = {"tests", "__pycache__"}
+SKIP_SUFFIXES = {".py", ".pyc"}
+
+
+def package(target: str) -> None:
+    dist_dir = Path("dist") / target
+    staging_dir = Path("build/staging") / target
+
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+
+    for item in dist_dir.iterdir():
+        if item.name in EXCLUDE or item.suffix in SKIP_SUFFIXES:
+            continue
+
+        dest = staging_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest)
+        else:
+            shutil.copy2(item, dest)
+            if target != "win":
+                mode = dest.stat().st_mode
+                dest.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare release staging directory")
+    parser.add_argument("--target", choices=["win", "mac", "linux"], required=True)
+    args = parser.parse_args()
+    package(args.target)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -1,0 +1,21 @@
+import subprocess
+from typing import Final
+
+
+def get_version() -> str:
+    """Return version from ``git describe --tags`` or a dev fallback.
+
+    When the repository has no tags or git is unavailable the
+    function returns ``0.0.0+dev``.
+    """
+    try:
+        output = subprocess.check_output(
+            ["git", "describe", "--tags"], stderr=subprocess.DEVNULL
+        )
+    except Exception:  # pragma: no cover - fallback logic
+        return "0.0.0+dev"
+    return output.decode().strip()
+
+
+__all__: Final = ["get_version"]
+__version__: str = get_version()


### PR DESCRIPTION
## Summary
- add `tools/versioning.get_version` to derive version from git tags
- introduce PyInstaller builder and release packaging helpers
- document local build workflow and hook pyproject version to the new module

## Testing
- `pip install pygame numpy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b98ff09688329b14f1ccef89a3106