### PR TITLE
feat: improve ui theming and highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ python -m scripts.run_cli --seed 123
 python -m scripts.run_gui
 ```
 
+## Borders & Highlights
+
+UI elements use three border widths (`border_xs`, `border_sm`, `border_md`) and
+rounded corners (`radius_sm`, `radius_md`, `radius_lg`). Highlight colors are
+drawn from the active theme's `palette.ui` (`neutral`, `accent`, `danger`,
+`warn`, `info`) ensuring consistent visuals across themes and scales.
+
 ## Loading & Frame Pacing
 
 The client boots into a lightweight loading scene. Resources such as

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -171,4 +171,7 @@
   ,"always_prefer_local": "Always prefer local"
   ,"always_prefer_cloud": "Always prefer cloud"
   ,"open_backups_folder": "Open backups folder"
+  ,"focus_ring": "Focus ring"
+  ,"hover_outline": "Hover outline"
+  ,"icon_label": "Icon label"
   }

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -171,4 +171,7 @@
   ,"always_prefer_local": "Всегда локальное"
   ,"always_prefer_cloud": "Всегда облачное"
   ,"open_backups_folder": "Открыть папку бэкапов"
+  ,"focus_ring": "Контур фокуса"
+  ,"hover_outline": "Обводка наведения"
+  ,"icon_label": "Подпись с иконкой"
   }

--- a/src/client/gfx/layers.py
+++ b/src/client/gfx/layers.py
@@ -4,8 +4,15 @@ from enum import IntEnum, auto
 
 
 class Layer(IntEnum):
-    BACKGROUND = 0
-    TILE = auto()
-    ENTITY = auto()
+    """Render layers ordered back to front."""
+
+    BG = 0
+    TILES = auto()
+    ENTITIES = auto()
     OVERLAY = auto()
     UI = auto()
+
+    # Backward compatibility -------------------------------------------------
+    BACKGROUND = BG
+    TILE = TILES
+    ENTITY = ENTITIES

--- a/src/client/ui/theme.py
+++ b/src/client/ui/theme.py
@@ -6,11 +6,35 @@ from typing import Dict
 
 
 @dataclass
+class UIPalette:
+    """Subset of theme colors used for highlights and UI states."""
+
+    neutral: tuple[int, int, int]
+    accent: tuple[int, int, int]
+    danger: tuple[int, int, int]
+    warn: tuple[int, int, int]
+    info: tuple[int, int, int]
+
+
+@dataclass
 class Theme:
     colors: Dict[str, tuple[int, int, int]]
+    palette: Dict[str, UIPalette]
     padding: int = 4
-    radius: int = 4
-    border_width: int = 2
+    radius_sm: int = 2
+    radius_md: int = 4
+    radius_lg: int = 8
+    border_xs: int = 1
+    border_sm: int = 2
+    border_md: int = 4
+
+    @property
+    def radius(self) -> int:
+        return self.radius_md
+
+    @property
+    def border_width(self) -> int:
+        return self.border_sm
 
 
 THEMES: Dict[str, Theme] = {
@@ -24,8 +48,17 @@ THEMES: Dict[str, Theme] = {
             "tooltip": (250, 250, 210),
             "toast": (0, 0, 0),
         },
+        palette={
+            "ui": UIPalette(
+                neutral=(120, 120, 120),
+                accent=(0, 120, 215),
+                danger=(200, 40, 40),
+                warn=(240, 170, 0),
+                info=(30, 144, 255),
+            )
+        },
         padding=6,
-        radius=6,
+        radius_md=6,
     ),
     "dark": Theme(
         colors={
@@ -37,8 +70,17 @@ THEMES: Dict[str, Theme] = {
             "tooltip": (50, 50, 50),
             "toast": (20, 20, 20),
         },
+        palette={
+            "ui": UIPalette(
+                neutral=(180, 180, 180),
+                accent=(0, 170, 255),
+                danger=(220, 80, 80),
+                warn=(240, 170, 0),
+                info=(80, 160, 255),
+            )
+        },
         padding=6,
-        radius=6,
+        radius_md=6,
     ),
     "apocalypse": Theme(
         colors={
@@ -50,8 +92,17 @@ THEMES: Dict[str, Theme] = {
             "tooltip": (60, 50, 50),
             "toast": (30, 20, 20),
         },
+        palette={
+            "ui": UIPalette(
+                neutral=(170, 130, 120),
+                accent=(200, 110, 60),
+                danger=(200, 60, 60),
+                warn=(220, 160, 70),
+                info=(120, 180, 200),
+            )
+        },
         padding=6,
-        radius=6,
+        radius_md=6,
     ),
     "high_contrast": Theme(
         colors={
@@ -63,9 +114,18 @@ THEMES: Dict[str, Theme] = {
             "tooltip": (10, 10, 10),
             "toast": (0, 0, 0),
         },
+        palette={
+            "ui": UIPalette(
+                neutral=(255, 255, 255),
+                accent=(255, 255, 0),
+                danger=(255, 0, 0),
+                warn=(255, 165, 0),
+                info=(0, 200, 255),
+            )
+        },
         padding=8,
-        radius=4,
-        border_width=4,
+        radius_md=4,
+        border_md=4,
     ),
 }
 

--- a/src/client/ui/widgets.py
+++ b/src/client/ui/widgets.py
@@ -43,6 +43,40 @@ class HoverHints:
 hover_hints = HoverHints()
 
 
+class FocusRing:
+    """Draw a ring around a widget to indicate keyboard focus."""
+
+    def __init__(self, rect: pygame.Rect) -> None:
+        self.rect = pygame.Rect(rect)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        th = get_theme()
+        pygame.draw.rect(
+            surface,
+            th.palette["ui"].accent,
+            self.rect.inflate(4, 4),
+            th.border_xs,
+            border_radius=th.radius_md,
+        )
+
+
+class HoverOutline:
+    """Thin outline used on mouse hover."""
+
+    def __init__(self, rect: pygame.Rect) -> None:
+        self.rect = pygame.Rect(rect)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        th = get_theme()
+        pygame.draw.rect(
+            surface,
+            th.palette["ui"].neutral,
+            self.rect.inflate(2, 2),
+            th.border_xs,
+            border_radius=th.radius_sm,
+        )
+
+
 class Button:
     """Clickable rectangular button."""
 
@@ -370,7 +404,8 @@ class IconLabel:
         self.font = pygame.font.SysFont(None, 18)
 
     def draw(self, surface: pygame.Surface, pos: tuple[int, int]) -> None:
-        img = self.font.render(f"{self.icon} {self.text}", True, (200, 200, 200))
+        th = get_theme()
+        img = self.font.render(f"{self.icon} {self.text}", True, th.colors["text"])
         surface.blit(img, pos)
 
 

--- a/tests/test_visual_helpers.py
+++ b/tests/test_visual_helpers.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import pathlib
+import pygame
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "src")])
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pygame.init()
+
+import types
+
+dummy_replay = types.ModuleType("scene_replay")
+dummy_replay.ReplayScene = type("ReplayScene", (), {})
+sys.modules["src.client.scene_replay"] = dummy_replay
+
+dummy_photo = types.ModuleType("scene_photo")
+dummy_photo.PhotoScene = type("PhotoScene", (), {})
+sys.modules["src.client.scene_photo"] = dummy_photo
+
+from src.client.gfx import anim
+from src.client import scene_game
+from src.client.ui import widgets
+
+
+def test_float_text_and_highlights_smoke() -> None:
+    pygame.init()
+    surf = pygame.Surface((100, 100), pygame.SRCALPHA)
+    ft = anim.FloatText("1", (10.5, 10.5))
+    ft.update(0.1)
+    ft.draw(surf)
+
+    scene = scene_game.GameScene.__new__(scene_game.GameScene)
+    scene.camera = type("Cam", (), {"zoom": 1.0, "world_to_screen": lambda self, p: p})()
+    player = type("P", (), {"x": 0, "y": 0})()
+    zombie = type("Z", (), {"x": 1, "y": 0})()
+    scene.state = type("State", (), {"active": 0, "players": [player], "zombies": [zombie]})()
+    scene.hover_tile = (2, 0)
+    scene._simple_path = scene_game.GameScene._simple_path.__get__(scene, scene_game.GameScene)
+
+    scene._draw_highlights(surf)
+
+    focus = widgets.FocusRing(pygame.Rect(0, 0, 10, 10))
+    hover = widgets.HoverOutline(pygame.Rect(0, 0, 10, 10))
+    icon = widgets.IconLabel("★", "")
+    focus.draw(surf)
+    hover.draw(surf)
+    icon.draw(surf, (0, 0))


### PR DESCRIPTION
## Summary
- expand theme palette with UI colors and scalable border/radius presets
- refine render layers, float text animation and scene highlights
- add focus/hover widgets and docs for borders & highlights

## Testing
- `pytest tests/test_visual_helpers.py -q`
- `pytest tests/test_accessibility_flags.py -q`
- `pytest tests/test_performance_flags.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5f7a24a08329a5376bfc460af2d6