### PR TITLE
feat: upgrade minimap and scene transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ A optional minimap gives a quick overview of the board. It encodes tile types
 by color, marks the current camera viewport and allows clicking to jump the
 camera. Both the visibility and size of the minimap are configurable.
 
+## Minimap 2.0 & Scene Transitions
+
+The minimap now ships with a legend clarifying tile colors, a frame showing the
+current viewport and clickable navigation that centers the camera on the chosen
+cell. Small unicode markers highlight events such as players or zombies. Scene
+changes between the menu, game and settings employ short fade or slide
+transitions for a smoother flow.
+
 ## Accessibility & Controller
 
 The settings menu now exposes an Accessibility tab. It offers an extended UI

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -175,4 +175,10 @@
   ,"focus_ring": "Focus ring"
   ,"hover_outline": "Hover outline"
   ,"icon_label": "Icon label"
+  ,"legend_wall": "Wall"
+  ,"legend_floor": "Floor"
+  ,"legend_loot": "Loot"
+  ,"legend_player": "Player"
+  ,"legend_zombie": "Zombie"
+  ,"legend_goal": "Goal"
   }

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -175,4 +175,10 @@
   ,"focus_ring": "Контур фокуса"
   ,"hover_outline": "Обводка наведения"
   ,"icon_label": "Подпись с иконкой"
+  ,"legend_wall": "Стена"
+  ,"legend_floor": "Пол"
+  ,"legend_loot": "Лут"
+  ,"legend_player": "Игрок"
+  ,"legend_zombie": "Зомби"
+  ,"legend_goal": "Цель"
   }

--- a/src/client/gfx/anim.py
+++ b/src/client/gfx/anim.py
@@ -116,6 +116,38 @@ class SlideTransition:
         surface.blit(self.old_surf, (-offset, 0))
 
 
+class SceneTransitions:
+    """Small factory for common scene transitions."""
+
+    @staticmethod
+    def fade_out(app, new_scene, duration: float = 0.3) -> FadeTransition:
+        return FadeTransition(app, new_scene, duration)
+
+    @staticmethod
+    def fade_in(app, duration: float = 0.3) -> FadeTransition:
+        trans = FadeTransition(app, app.scene, duration)
+        trans.phase = "in"
+        trans.time = 0.0
+        return trans
+
+    @staticmethod
+    def slide_out(app, new_scene, duration: float = 0.3) -> SlideTransition:
+        return SlideTransition(app, new_scene, duration)
+
+    @staticmethod
+    def slide_in(app, new_scene, duration: float = 0.3) -> SlideTransition:
+        class _SlideIn(SlideTransition):
+            def draw(self, surface: pygame.Surface) -> None:  # type: ignore[override]
+                w, _ = surface.get_size()
+                t = min(self.time / self.duration, 1.0)
+                t = ease_in_out(t)
+                offset = int((1.0 - t) * w)
+                surface.blit(self.old_surf, (0, 0))
+                surface.blit(self.new_surf, (offset, 0))
+
+        return _SlideIn(app, new_scene, duration)
+
+
 # lightweight animation primitives used by the game scene -----------------
 
 

--- a/src/client/ui/widgets.py
+++ b/src/client/ui/widgets.py
@@ -77,6 +77,27 @@ class HoverOutline:
         )
 
 
+class LegendWidget:
+    """Display a list of colored squares with labels."""
+
+    def __init__(self, items: list[tuple[tuple[int, int, int], str]], rect: pygame.Rect) -> None:
+        self.items = items
+        self.rect = pygame.Rect(rect)
+        self.font = pygame.font.SysFont(None, 16)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        th = get_theme()
+        x, y = self.rect.topleft
+        size = 10
+        for color, label in self.items:
+            square = pygame.Rect(x, y, size, size)
+            surface.fill(color, square)
+            pygame.draw.rect(surface, th.colors["border"], square, 1)
+            img = self.font.render(label, True, th.colors["text"])
+            surface.blit(img, (x + size + th.padding, y - 2))
+            y += size + th.padding
+
+
 class Panel:
     """Simple container with rounded corners and a subtle drop shadow."""
 

--- a/src/gamecore/i18n.py
+++ b/src/gamecore/i18n.py
@@ -167,6 +167,14 @@ INVERT_ZOOM = "invert_zoom"
 LARGE_TEXT = "large_text"
 NIGHT_VIGNETTE = "night_vignette"
 
+# minimap legend -------------------------------------------------------------
+LEGEND_WALL = "legend_wall"
+LEGEND_FLOOR = "legend_floor"
+LEGEND_LOOT = "legend_loot"
+LEGEND_PLAYER = "legend_player"
+LEGEND_ZOMBIE = "legend_zombie"
+LEGEND_GOAL = "legend_goal"
+
 # invite related --------------------------------------------------------------
 INVITE = "INVITE"
 COPY_LINK = "COPY_LINK"

--- a/tests/test_minimap_jump.py
+++ b/tests/test_minimap_jump.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pathlib
+import pygame
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "src")])
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pygame.init()
+
+from src.client.gfx.camera import SmoothCamera
+from src.client.gfx.tileset import TILE_SIZE
+
+
+def test_jump_stays_within_bounds() -> None:
+    cam = SmoothCamera((200, 200), (20 * TILE_SIZE, 20 * TILE_SIZE))
+    cam.jump_to((-5, -5))
+    assert cam.x >= 0 and cam.y >= 0
+    cam.jump_to((50, 50))
+    max_x = max(0.0, cam.world_w - cam.screen_w / cam.zoom)
+    max_y = max(0.0, cam.world_h - cam.screen_h / cam.zoom)
+    assert cam.x <= max_x and cam.y <= max_y


### PR DESCRIPTION
## Summary
- add camera.jump_to and clamp helpers
- refresh minimap with legend, markers and cursor overlay
- introduce configurable fade/slide scene transitions

## Testing
- `pytest tests/test_minimap_jump.py tests/test_locales_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_689c683392a48329aef3e8cc9c3a7e5c