### PR TITLE
Ensure entry scripts configure src on sys.path

### DIFF
--- a/scripts/run_cli.py
+++ b/scripts/run_cli.py
@@ -1,3 +1,11 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
 from gamecore.cli import main
 
 if __name__ == "__main__":

--- a/scripts/run_gui.py
+++ b/scripts/run_gui.py
@@ -1,4 +1,11 @@
 """Run the pygame GUI."""
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
 
 import argparse
 

--- a/scripts/run_master.py
+++ b/scripts/run_master.py
@@ -1,6 +1,14 @@
 """Entry point to run the master server."""
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
 import argparse
 import asyncio
 

--- a/scripts/run_server.py
+++ b/scripts/run_server.py
@@ -1,6 +1,14 @@
 """Entry point to run the websocket server."""
 from __future__ import annotations
 
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
 import argparse
 import asyncio
 

--- a/scripts/steam_upload.py
+++ b/scripts/steam_upload.py
@@ -13,11 +13,17 @@ This script fills in VDF templates located in ``steam/`` and invokes the
 """
 
 from __future__ import annotations
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
 
 import argparse
 import os
 import subprocess
-from pathlib import Path
 
 from tools.versioning import get_version
 


### PR DESCRIPTION
## Summary
- ensure all scripts add the repository `src/` directory to `sys.path`
- allow `python scripts/run_gui.py` and other entry points to work without setting `PYTHONPATH`

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: KeyboardInterrupt after 33 passed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c6fb215488329aca8b3bffc056ce6