### PR TITLE
refactor: extract Scene base class to break import cycle

### DIFF
--- a/src/client/app.py
+++ b/src/client/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import pygame
 import time
-from typing import Optional
 from pathlib import Path
 import logging
 
@@ -20,23 +19,7 @@ from .gfx import postfx
 from .ui import theme as ui_theme
 from .scene_loading import LoadingScene
 
-
-class Scene:
-    """Base class for scenes."""
-
-    def __init__(self, app: "App") -> None:
-        self.app = app
-        self.next_scene: Optional[Scene] = None
-
-    def handle_event(self, event: pygame.event.Event) -> None:
-        """Handle pygame events."""
-
-    def update(self, dt: float) -> None:
-        """Update scene state."""
-
-    def draw(self, surface: pygame.Surface) -> None:
-        """Draw scene to the surface."""
-
+from .scene_base import Scene
 
 class App:
     """Pygame application managing scenes."""

--- a/src/client/scene_base.py
+++ b/src/client/scene_base.py
@@ -1,0 +1,33 @@
+"""Base scene class used by all game scenes."""
+from __future__ import annotations
+
+import pygame
+from typing import Optional
+
+
+class Scene:
+    """Common base class for all scenes.
+
+    Provides no functionality by default but defines the interface expected
+    by :class:`App` and other scenes.
+    """
+
+    def __init__(self, app) -> None:
+        """Store reference to the application instance."""
+        self.app = app
+        self.next_scene: Optional[Scene] = None
+
+    def enter(self) -> None:  # pragma: no cover - interface stub
+        """Called when the scene becomes active."""
+
+    def exit(self) -> None:  # pragma: no cover - interface stub
+        """Called when the scene is deactivated."""
+
+    def handle_event(self, event: pygame.event.Event) -> None:  # pragma: no cover - interface stub
+        """Handle a pygame event."""
+
+    def update(self, dt: float) -> None:  # pragma: no cover - interface stub
+        """Update scene logic."""
+
+    def draw(self, screen: pygame.Surface) -> None:  # pragma: no cover - interface stub
+        """Draw scene contents to ``screen``."""

--- a/src/client/scene_demo_end.py
+++ b/src/client/scene_demo_end.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pygame
 
 from gamecore.i18n import gettext as _
-from .app import Scene
+from .scene_base import Scene
 from .ui.widgets import Button
 
 try:  # pragma: no cover - optional dependency

--- a/src/client/scene_game.py
+++ b/src/client/scene_game.py
@@ -6,7 +6,7 @@ import math
 import pygame
 from typing import Any
 
-from .app import Scene
+from .scene_base import Scene
 from .gfx.tileset import TILE_SIZE, Tileset
 from .gfx import anim
 from .gfx.camera import SmoothCamera

--- a/src/client/scene_menu.py
+++ b/src/client/scene_menu.py
@@ -6,7 +6,7 @@ import pygame
 from gamecore.i18n import gettext as _
 from gamecore import achievements, rules
 from integrations import steam
-from .app import Scene
+from .scene_base import Scene
 from .ui.widgets import Button, Card, NameField, ColorPicker, ModalConfirm
 from . import clipboard
 from .sfx import set_volume

--- a/src/client/scene_online.py
+++ b/src/client/scene_online.py
@@ -11,7 +11,7 @@ from gamecore.config import load_config
 from gamecore.i18n import gettext as _
 from net.master_api import MasterMessage, encode_master_message, decode_master_message
 from net.protocol import MessageType
-from .app import Scene
+from .scene_base import Scene
 from .net_client import NetClient, parse_invite_url
 from . import clipboard
 

--- a/src/client/scene_photo.py
+++ b/src/client/scene_photo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pygame
 
-from .app import Scene
+from .scene_base import Scene
 from .gfx.camera import SmoothCamera
 from .gfx import postfx
 from gamecore import config as gconfig, rules

--- a/src/client/scene_replay.py
+++ b/src/client/scene_replay.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import pygame
 from pathlib import Path
 
-from .app import Scene
+from .scene_base import Scene
 from gamecore.i18n import gettext as _
 from replay import player as replay_player
 

--- a/src/client/scene_sandbox.py
+++ b/src/client/scene_sandbox.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pygame
 
-from .app import Scene
+from .scene_base import Scene
 from .ui.widgets import Button, TilePalette, Toolbar
 from .gfx.tileset import TILE_SIZE
 from gamecore import board as gboard, saveio

--- a/src/client/scene_save_conflict.py
+++ b/src/client/scene_save_conflict.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from gamecore import config as gconfig
 from gamecore.i18n import gettext as _
-from .app import Scene
+from .scene_base import Scene
 from .ui.widgets import Button
 
 

--- a/src/client/scene_settings.py
+++ b/src/client/scene_settings.py
@@ -14,7 +14,7 @@ import pygame
 from gamecore import config as gconfig
 from gamecore import i18n
 from gamecore.i18n import gettext as _
-from .app import Scene
+from .scene_base import Scene
 from .input import InputManager
 from . import sfx
 from .ui.widgets import (

--- a/src/client/scene_tutorial.py
+++ b/src/client/scene_tutorial.py
@@ -12,7 +12,7 @@ import pygame
 
 from gamecore import config as gconfig
 from gamecore.i18n import gettext as _
-from .app import Scene
+from .scene_base import Scene
 
 
 class TutorialScene(Scene):


### PR DESCRIPTION
## Summary
- move Scene base class into new `scene_base.py`
- update all scenes and `app.py` to import from `scene_base`
- remove circular dependency between `app.py` and `scene_replay.py`

## Testing
- `python -m py_compile src/client/app.py src/client/scene_base.py src/client/scene_replay.py`
- `PYTHONPATH=src python - <<'PY'
import importlib
m = importlib.import_module('client.app')
print('App imported OK:', hasattr(m, 'App'))
PY`
- `bash -lc 'SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy python scripts/run_gui.py >/tmp/run_gui.log'`

------
https://chatgpt.com/codex/tasks/task_e_689c73531ad48329a901e726da8172f2