### PR TITLE
Add runtime-safe tools shim with guarded imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ python tools/package_release.py --target linux
 
 This gathers the built binary and runtime resources in `build/staging/<platform>/`.
 
+## Runtime tools shim
+
+Release builds do not ship with the development helpers found in the top level
+`tools/` directory.  A lightweight package under `src/tools` provides a safe
+shim so `import tools` always succeeds.  When matching modules exist in the
+`tools/` folder they are imported transparently; otherwise the shim returns
+no‑op placeholders and logs a warning.  This keeps production builds small
+while still allowing optional helpers during development.
+
 
 ## CI: Artifacts & Steam Upload
 

--- a/src/client/app.py
+++ b/src/client/app.py
@@ -176,7 +176,9 @@ def main(demo: bool = False, safe_mode: bool = False) -> None:
         log_file.write_text("", encoding="utf-8")
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
-    fh = logging.FileHandler(log_file)
+    fh = logging.FileHandler(log_file, encoding="utf-8")
+    fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    fh.setFormatter(logging.Formatter(fmt))
     root_logger.addHandler(fh)
     logging.info(
         "python=%s pygame=%s os=%s cwd=%s meipass=%s safe_mode=%s",

--- a/src/client/gfx/tileset.py
+++ b/src/client/gfx/tileset.py
@@ -47,7 +47,10 @@ class Tileset:
         to render the tiles using Pillow.
         """
 
-        from tools import build_tiles
+        try:
+            from tools import build_tiles  # runtime shim or real module
+        except Exception:  # pragma: no cover - fallback should not trigger
+            from tools import _Noop as build_tiles
 
         mapping_path: Path | None = None
         for loc in (root / "textures.json", root / "scripts" / "textures.json"):

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,0 +1,57 @@
+"""Runtime shim for optional developer tools.
+
+This package provides a safe stub for ``import tools`` in release builds
+where the developer-only ``tools`` package is absent.  The shim exposes
+no-op placeholders for common entry points and lazily proxies to real
+modules if a ``tools`` directory exists next to the project root.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class _Noop:
+    """Object that ignores all calls and attribute access."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def __getattr__(self, name: str) -> "_Noop":
+        return self
+
+
+# Extend import search path with the developer ``tools`` directory if it exists
+_DEV_DIR = Path(__file__).resolve().parents[2] / "tools"
+if _DEV_DIR.is_dir():
+    __path__.append(str(_DEV_DIR))  # type: ignore[name-defined]
+
+
+def _load(name: str) -> Any:
+    try:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    except Exception:
+        log.warning("[tools shim] missing tools.%s", name)
+        obj = _Noop()
+        globals()[name] = obj
+        return obj
+
+
+# Commonly expected helpers -------------------------------------------------
+profiler = _load("profiler")
+build = _load("build")
+assets = _load("assets")
+misc = _load("misc")
+
+
+def __getattr__(name: str) -> Any:
+    return _load(name)
+
+
+__all__ = ["_Noop", "profiler", "build", "assets", "misc"]

--- a/tests/test_tools_shim.py
+++ b/tests/test_tools_shim.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def _import_shim(monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    src = root / "src"
+    monkeypatch.syspath_prepend(str(src))
+    monkeypatch.delitem(sys.modules, "tools", raising=False)
+    return importlib.import_module("tools")
+
+
+def test_noop_available(monkeypatch):
+    tools = _import_shim(monkeypatch)
+    assert tools.profiler.start() is None
+    assert tools.profiler.stop() is None
+
+
+def test_proxy_real_module(monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    profiler_file = root / "tools" / "profiler.py"
+    profiler_file.write_text(
+        "def start():\n    return 'started'\n\n"
+        "def stop():\n    return 'stopped'\n",
+        encoding="utf-8",
+    )
+    try:
+        tools = _import_shim(monkeypatch)
+        assert tools.profiler.start() == "started"
+        assert tools.profiler.stop() == "stopped"
+    finally:
+        monkeypatch.delitem(sys.modules, "tools.profiler", raising=False)
+        profiler_file.unlink()
+        cache = profiler_file.parent / "__pycache__"
+        if cache.exists():
+            for f in cache.glob("profiler.*"):
+                f.unlink()
+            try:
+                cache.rmdir()
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary
- provide `src/tools` shim so `import tools` works even without dev helpers
- log shim warnings to client app log
- guard runtime imports and add tests for shim behaviour

## Testing
- `pytest tests/test_tools_shim.py tests/test_assets_bootstrap.py`


------
https://chatgpt.com/codex/tasks/task_e_689c92e544b88329b3b9bdc4c52f6c72