### PR TITLE
Restore core gameplay primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,18 @@ python -m scripts.run_gui
 
 ## Controls & Turn Flow
 
-The playable prototype supports a tiny subset of the final game's controls.  A
-unit is selected with the left mouse button, right clicking issues a move or
-attack depending on the target and **Space** ends the turn.  The rules module
-tracks action points and validates that moves stay within range and do not pass
-through walls.  Each successful action appends a short entry to the event log
+The playable prototype supports a tiny subset of the final game's controls:
+
+* **LMB** – select a unit or target
+* **RMB** – move to a cell or attack an enemy
+* **Space** – end the current turn
+* **Esc** – pause
+* **F1** – toggle a help overlay with the current bindings
+
+The rules module tracks action points and validates that moves stay within
+range and do not pass through walls.  Failed actions return a localised reason
+which the client displays as a small toast message so the player knows why an
+order was rejected.  Successful actions append a short entry to the event log
 (``Move``, ``Hit`` or ``End Turn``).
 
 ## Game Flow: New Game / Continue / Load

--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -14,9 +14,11 @@
   "out_of_ap": "Out of AP",
   "blocked": "Blocked",
   "out_of_range": "Out of range",
+  "not_your_turn": "Not your turn",
   "log_move": "Move",
   "log_hit": "Hit",
   "log_miss": "Miss",
+  "log_blocked": "Blocked",
   "log_end": "End Turn"
 }
 

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -14,9 +14,11 @@
   "out_of_ap": "Нет ОД",
   "blocked": "Заблокировано",
   "out_of_range": "Вне радиуса",
+  "not_your_turn": "Не ваш ход",
   "log_move": "Ход",
   "log_hit": "Удар",
   "log_miss": "Промах",
+  "log_blocked": "Блокировано",
   "log_end": "Конец хода"
 }
 

--- a/src/client/gfx/anim.py
+++ b/src/client/gfx/anim.py
@@ -12,6 +12,8 @@ import pygame
 
 
 class FloatText:
+    """Simple piece of combat text that rises and fades."""
+
     def __init__(self, text: str, pos: tuple[int, int]) -> None:
         self.text = text
         self.x, self.y = pos
@@ -28,11 +30,22 @@ class FloatText:
         surface.blit(img, (self.x, self.y))
 
 
-def screen_shake(camera, intensity: float = 1.0) -> None:  # pragma: no cover - visual
-    """Placeholder for a tiny camera shake effect."""
-    # In tests the function merely exists so importing modules that call it do
-    # not fail; no actual shaking is required.
+def float_text(text: str, pos: tuple[int, int]) -> FloatText:
+    """Convenience factory returning a :class:`FloatText` instance."""
+
+    return FloatText(text, pos)
+
+
+def screen_shake(camera, amplitude: float = 1.0, duration: float = 0.2) -> None:  # pragma: no cover - visual
+    """Tiny placeholder for a camera shake effect.
+
+    The implementation is intentionally light weight – the tests only need the
+    function to exist so modules can call it after an attack.  No actual shaking
+    is required.
+    """
+
+    _ = (camera, amplitude, duration)  # unused but keeps signature stable
     return None
 
 
-__all__ = ["FloatText", "screen_shake"]
+__all__ = ["FloatText", "float_text", "screen_shake"]

--- a/src/client/gfx/camera.py
+++ b/src/client/gfx/camera.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass
 
 @dataclass
 class SmoothCamera:
+    """Small camera helper with basic panning and zooming.
+
+    ``screen_size`` and ``world_size`` are expressed in pixels.  The camera
+    keeps the top left world coordinate in ``x``/``y`` and converts between
+    world and screen space via :meth:`world_to_screen` and
+    :meth:`screen_to_world`.
+    """
+
     screen_size: tuple[int, int]
     world_size: tuple[int, int]
     zoom: float = 1.0
@@ -24,17 +32,50 @@ class SmoothCamera:
         self.y = 0.0
 
     # movement ------------------------------------------------------------
-    def clamp(self) -> None:
+    def clamp_to_bounds(self) -> None:
+        """Clamp the view so it stays within the world bounds."""
+
         max_x = max(0.0, self.world_w - self.screen_w / self.zoom)
         max_y = max(0.0, self.world_h - self.screen_h / self.zoom)
         self.x = max(0.0, min(self.x, max_x))
         self.y = max(0.0, min(self.y, max_y))
 
+    clamp = clamp_to_bounds  # backwards compatibility
+
     def jump_to(self, cell: tuple[int, int]) -> None:
+        """Centre the camera on ``cell`` expressed in world pixels."""
+
         cx, cy = cell
         self.x = float(cx) - self.screen_w / (2 * self.zoom)
         self.y = float(cy) - self.screen_h / (2 * self.zoom)
-        self.clamp()
+        self.clamp_to_bounds()
+
+    # coordinate conversions ---------------------------------------------
+    def world_to_screen(self, pos: tuple[float, float]) -> tuple[int, int]:
+        """Convert world coordinates to screen pixels."""
+
+        sx = int((pos[0] - self.x) * self.zoom)
+        sy = int((pos[1] - self.y) * self.zoom)
+        return sx, sy
+
+    def screen_to_world(self, pos: tuple[float, float]) -> tuple[float, float]:
+        """Inverse of :meth:`world_to_screen`."""
+
+        wx = pos[0] / self.zoom + self.x
+        wy = pos[1] / self.zoom + self.y
+        return wx, wy
+
+    # zoom ----------------------------------------------------------------
+    def zoom_at(self, amount: float, cursor: tuple[int, int]) -> None:
+        """Zoom towards ``cursor`` keeping the world position underneath it."""
+
+        old_zoom = self.zoom
+        self.zoom = max(0.25, min(4.0, self.zoom * (1.0 + amount)))
+        if self.zoom != old_zoom:
+            wx, wy = self.screen_to_world(cursor)
+            self.x = wx - cursor[0] / self.zoom
+            self.y = wy - cursor[1] / self.zoom
+            self.clamp_to_bounds()
 
     # the real project exposes ``update`` and smooth following.  Tests do not
     # rely on those features so they are intentionally omitted.

--- a/src/client/input_map.py
+++ b/src/client/input_map.py
@@ -9,9 +9,12 @@ class InputMap:
     """Translate pygame events into high level action strings."""
 
     def __init__(self) -> None:
+        """Create the input map and disable key repeat."""
+
+        pygame.key.set_repeat()  # disable key repeat – actions fire once
         self._map: dict[tuple[str, int], str] = {
-            ("mouse", 1): "select",
-            ("mouse", 3): "move",
+            ("mouse", 1): "select",  # left mouse button
+            ("mouse", 3): "action",  # right mouse button – move/attack
             ("key", pygame.K_SPACE): "end_turn",
             ("key", pygame.K_ESCAPE): "pause",
             ("key", pygame.K_F1): "help",

--- a/src/client/scene_game.py
+++ b/src/client/scene_game.py
@@ -10,11 +10,13 @@ that exposes the few attributes tests interact with: a ``state`` object, a
 """
 
 import pygame
+from collections import deque
+from typing import Deque, Tuple
 
 from .gfx.camera import SmoothCamera
 from .gfx.tileset import TILE_SIZE
-from .ui.widgets import HelpOverlay
-from gamecore import board as gboard, rules
+from .ui.widgets import HelpOverlay, Toast
+from gamecore import board as gboard, rules, validate
 
 hover_hints = []  # tests patch this with translated help strings
 
@@ -30,16 +32,67 @@ class GameScene:
             (b.width * TILE_SIZE, b.height * TILE_SIZE),
         )
         self.help = HelpOverlay(app.input_map)
+        self.selected = self.state.current
+        self.toasts: list[Toast] = []
+        self.queue: Deque[Tuple[str, tuple[int, int]]] = deque()
 
-    # the real scene is interactive.  For tests we only need stubs -------------
-    def handle_event(self, event: pygame.event.Event) -> None:  # pragma: no cover - trivial
-        pass
+    # helpers -----------------------------------------------------------
+    def cell_from_screen(self, pos: tuple[int, int]) -> tuple[int, int] | None:
+        wx, wy = self.camera.screen_to_world(pos)
+        cell = int(wx // TILE_SIZE), int(wy // TILE_SIZE)
+        b = self.state.board
+        if 0 <= cell[0] < b.width and 0 <= cell[1] < b.height:
+            return cell
+        return None
 
-    def update(self, dt: float) -> None:  # pragma: no cover - trivial
-        pass
+    def toast(self, text: str) -> None:
+        self.toasts.append(Toast(text))
+
+    # input --------------------------------------------------------------
+    def handle_event(self, event: pygame.event.Event) -> None:
+        action = self.app.input_map.map_event(event)
+        if action == "help":
+            self.help.toggle()
+            return
+        if action == "pause":  # pragma: no cover - minimal
+            return
+        if action == "end_turn":
+            rules.end_turn(self.state)
+            self.selected = self.state.current
+            return
+        if action == "select" and hasattr(event, "pos"):
+            cell = self.cell_from_screen(event.pos)
+            if cell:
+                for p in self.state.players:
+                    if (p.x, p.y) == cell:
+                        self.selected = p
+                        break
+            return
+        if action == "action" and hasattr(event, "pos"):
+            cell = self.cell_from_screen(event.pos)
+            if cell:
+                self.queue.append(("action", cell))
+
+    # processing ---------------------------------------------------------
+    def update(self, dt: float) -> None:
+        if self.queue:
+            act, cell = self.queue.popleft()
+            if act == "action" and self.selected is self.state.current:
+                target = next((p for p in self.state.players if (p.x, p.y) == cell and p is not self.selected), None)
+                if target:
+                    ok, reason = rules.attack(self.state, target)
+                else:
+                    ok, reason = rules.move(self.state, cell)
+                if not ok and reason:
+                    self.toast(reason)
 
     def draw(self, surf: pygame.Surface) -> None:  # pragma: no cover - visual
         surf.fill((0, 0, 0))
+        # draw toasts
+        y = 10
+        for t in self.toasts:
+            t.draw(surf, y)
+            y += 20
 
 
 __all__ = ["GameScene", "hover_hints"]

--- a/src/client/ui/widgets.py
+++ b/src/client/ui/widgets.py
@@ -12,6 +12,8 @@ from typing import Callable, List
 
 import pygame
 
+from ..gfx.tileset import TILE_SIZE
+
 _font: pygame.font.Font | None = None
 hover_hints: List[str] = []  # filled by tests; mirrors real project
 
@@ -201,7 +203,7 @@ class Minimap:
             relx = (event.pos[0] - self.rect.x) / self.rect.width
             rely = (event.pos[1] - self.rect.y) / self.rect.height
             cell = (int(relx * self.board_w), int(rely * self.board_h))
-            self.camera.jump_to(cell)
+            self.camera.jump_to((cell[0] * TILE_SIZE, cell[1] * TILE_SIZE))
 
 
 __all__ = [

--- a/src/gamecore/events.py
+++ b/src/gamecore/events.py
@@ -3,6 +3,7 @@
 MOVE = "Move"
 HIT = "Hit"
 MISS = "Miss"
+BLOCKED = "Blocked"
 END_TURN = "End Turn"
 
-__all__ = ["MOVE", "HIT", "MISS", "END_TURN"]
+__all__ = ["MOVE", "HIT", "MISS", "BLOCKED", "END_TURN"]

--- a/src/gamecore/validate.py
+++ b/src/gamecore/validate.py
@@ -13,6 +13,14 @@ from typing import Tuple
 from .i18n import gettext as _
 from . import rules
 
+# canonical reason codes used by ``check_action``
+REASONS = {
+    "blocked": _("blocked"),
+    "out_of_range": _("out_of_range"),
+    "out_of_ap": _("out_of_ap"),
+    "not_your_turn": _("not_your_turn"),
+}
+
 
 def _manhattan(a: Tuple[int, int], b: Tuple[int, int]) -> int:
     return abs(a[0] - b[0]) + abs(a[1] - b[1])
@@ -22,12 +30,12 @@ def can_move(state, dest: Tuple[int, int]) -> str | None:
     player = state.current
     path = state.board.find_path((player.x, player.y), dest)
     if not path:
-        return _("blocked")
+        return REASONS["blocked"]
     steps = len(path) - 1
     if steps > rules.MOVE_RANGE:
-        return _("out_of_range")
+        return REASONS["out_of_range"]
     if steps * rules.MOVE_COST > getattr(player, "ap", 0):
-        return _("out_of_ap")
+        return REASONS["out_of_ap"]
     return None
 
 
@@ -35,9 +43,9 @@ def can_attack(state, target) -> str | None:
     player = state.current
     dist = _manhattan((player.x, player.y), (target.x, target.y))
     if dist > rules.ATTACK_RANGE:
-        return _("out_of_range")
+        return REASONS["out_of_range"]
     if getattr(player, "ap", 0) < rules.ATTACK_COST:
-        return _("out_of_ap")
+        return REASONS["out_of_ap"]
     return None
 
 
@@ -45,4 +53,21 @@ def can_end_turn(state) -> str | None:  # pragma: no cover - trivial
     return None
 
 
-__all__ = ["can_move", "can_attack", "can_end_turn"]
+def check_action(func, *args, **kwargs):
+    """Return ``(ok, reason_code)`` for a validation function.
+
+    ``func`` must be one of the ``can_*`` helpers above.  The function is
+    executed and its *translated* reason string is mapped back to the canonical
+    reason code.  ``ok`` is ``True`` when no reason was returned.
+    """
+
+    reason = func(*args, **kwargs)
+    if reason is None:
+        return True, None
+    for code, text in REASONS.items():
+        if reason == text:
+            return False, code
+    return False, reason
+
+
+__all__ = ["can_move", "can_attack", "can_end_turn", "check_action", "REASONS"]

--- a/tests/test_minimap_hit.py
+++ b/tests/test_minimap_hit.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pathlib
+import pygame
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "src")])
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pygame.init()
+
+from src.client.gfx.camera import SmoothCamera
+from src.client.gfx.tileset import TILE_SIZE
+from src.client.ui import widgets
+
+
+def test_minimap_click_and_draw() -> None:
+    cam = SmoothCamera((100, 100), (10 * TILE_SIZE, 10 * TILE_SIZE))
+    mini = widgets.Minimap(pygame.Rect(0, 0, 100, 100), (10, 10), cam)
+
+    # click roughly in the centre -> cell (5,5)
+    event = pygame.event.Event(pygame.MOUSEBUTTONDOWN, pos=(50, 50), button=1)
+    mini.handle_event(event)
+    assert int(cam.x) == 5 * TILE_SIZE - cam.screen_w // 2
+    assert int(cam.y) == 5 * TILE_SIZE - cam.screen_h // 2
+
+    # drawing the minimap renders the current view rectangle in white
+    surf = pygame.Surface((100, 100))
+    mini.draw(surf)
+    vx = int((cam.x / cam.world_w) * mini.rect.width)
+    vy = int((cam.y / cam.world_h) * mini.rect.height)
+    assert surf.get_at((vx, vy))[:3] == (255, 255, 255)


### PR DESCRIPTION
## Summary
- Centralise input handling with explicit mappings and disabled key repeat
- Expand SmoothCamera with world/screen conversions, bounds clamping and zooming
- Implement basic GameScene logic with action queue, toasts and minimap support
- Expose validation reasons via canonical codes and add missing translations
- Add minimap click test and update controls documentation

## Testing
- `pytest -q tests/test_turn_flow.py tests/test_minimap_hit.py`


------
https://chatgpt.com/codex/tasks/task_e_689ce1e176c083299331b4c1d2009f9f