### PR TITLE
Add configurable key bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The playable prototype supports a tiny subset of the final game's controls:
 * **Esc** – pause
 * **F1** – toggle a help overlay with the current bindings
 
+### Keybinds
+
+Custom key bindings are stored in `~/.oko_zombie/config.json` under the
+`"keybinds"` section. They can be changed in the **Settings** menu via the
+corresponding buttons.
+
 The rules module tracks action points and validates that moves stay within
 range and do not pass through walls.  Failed actions return a localised reason
 which the client displays as a small toast message so the player knows why an

--- a/src/client/input_map.py
+++ b/src/client/input_map.py
@@ -1,4 +1,4 @@
-"""Centralised input mapping."""
+"""Centralised input mapping and key binding management."""
 
 from __future__ import annotations
 
@@ -28,5 +28,66 @@ class InputMap:
         return None
 
 
-__all__ = ["InputMap"]
+class InputManager:
+    """Store and manage action → key bindings."""
+
+    def __init__(self, keybinds: dict[str, int] | None = None) -> None:
+        self._binds = keybinds or self.default_keybinds()
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def default_keybinds() -> dict[str, int]:
+        """Return default bindings using common WASD controls."""
+
+        return {
+            "move_up": pygame.K_w,
+            "move_down": pygame.K_s,
+            "move_left": pygame.K_a,
+            "move_right": pygame.K_d,
+            "end_turn": pygame.K_SPACE,
+            "rest": pygame.K_r,
+            "scavenge": pygame.K_g,
+            "pause": pygame.K_ESCAPE,
+        }
+
+    def get(self, action: str) -> int:
+        """Return the key bound to ``action``."""
+
+        return self._binds[action]
+
+    def set(self, action: str, key: int) -> None:
+        """Bind ``action`` to ``key``."""
+
+        self._binds[action] = int(key)
+
+    def to_config(self) -> dict[str, int]:
+        """Return bindings in a serialisable form."""
+
+        return dict(self._binds)
+
+    @classmethod
+    def from_config(cls, cfg: dict[str, int] | None) -> "InputManager":
+        """Create manager from ``cfg`` using defaults for missing keys."""
+
+        if not isinstance(cfg, dict):
+            return cls(cls.default_keybinds())
+        defaults = cls.default_keybinds()
+        for action, key in cfg.items():
+            if action in defaults and isinstance(key, int):
+                defaults[action] = int(key)
+        return cls(defaults)
+
+
+def name_for_key(key: int) -> str:
+    """Return human readable name for ``key``."""
+
+    try:
+        return pygame.key.name(key)
+    except Exception:  # pragma: no cover - defensive
+        return str(key)
+
+
+__all__ = ["InputMap", "InputManager", "name_for_key"]
 

--- a/src/gamecore/config.py
+++ b/src/gamecore/config.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "disable_online": False,
     "ui_theme": "dark",
     "language": "en",
+    "keybinds": {},
 }
 
 
@@ -31,6 +32,15 @@ def load_config() -> Dict[str, Any]:
         data = {}
     cfg = DEFAULT_CONFIG.copy()
     cfg.update(data)
+    try:
+        from client.input_map import InputManager
+
+        if not isinstance(cfg.get("keybinds"), dict):
+            cfg["keybinds"] = InputManager.default_keybinds()
+        else:
+            cfg["keybinds"] = InputManager.from_config(cfg.get("keybinds")).to_config()
+    except Exception:  # pragma: no cover - defensive
+        pass
     return cfg
 
 

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pathlib
+
+import pygame
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "src")])
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pygame.init()
+
+from client.input_map import InputManager  # noqa: E402  pylint: disable=wrong-import-position
+from client.ui import widgets  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_defaults_and_get_set() -> None:
+    im = InputManager.from_config(None)
+    assert im.get("move_up") == pygame.K_w
+    im.set("end_turn", pygame.K_RETURN)
+    assert im.get("end_turn") == pygame.K_RETURN
+
+
+def test_serialization_roundtrip() -> None:
+    im = InputManager.from_config(None)
+    im.set("rest", pygame.K_x)
+    cfg = im.to_config()
+    im2 = InputManager.from_config(cfg)
+    assert im2.get("rest") == pygame.K_x
+
+
+def test_rebind_button_updates_manager() -> None:
+    widgets.init_ui()
+    im = InputManager.from_config(None)
+    changed: list[tuple[str, int]] = []
+    btn = widgets.RebindButton(pygame.Rect(0, 0, 100, 30), "end_turn", im, lambda a, k: changed.append((a, k)))
+    btn.listening = True
+    btn.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_z))
+    assert im.get("end_turn") == pygame.K_z
+    assert changed and changed[-1] == ("end_turn", pygame.K_z)
+


### PR DESCRIPTION
## Summary
- implement simple `InputManager` with default WASD bindings and serialization helpers
- persist key bindings in config and expose them through `App`
- allow rebinding keys in Settings via improved `RebindButton`

## Testing
- `pytest tests/test_input_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8ac855d483298ed9d3487a077550