### PR TITLE
Refactor hover hint singleton and guard against shadowing

### DIFF
--- a/src/client/scene_game.py
+++ b/src/client/scene_game.py
@@ -22,7 +22,7 @@ from .ui.theme import get_theme
 from gamecore import board as gboard, rules, validate
 from gamecore.i18n import safe_get
 
-hover_hints = []  # tests patch this with translated help strings
+hints_list: list[str] = []  # tests patch this with translated help strings
 
 
 class GameScene(Scene):
@@ -205,4 +205,4 @@ class GameScene(Scene):
             y += 20
 
 
-__all__ = ["GameScene", "hover_hints"]
+__all__ = ["GameScene", "hints_list"]

--- a/src/client/scene_settings.py
+++ b/src/client/scene_settings.py
@@ -17,7 +17,8 @@ from gamecore.i18n import gettext as _, safe_get, set_language
 from .scene_base import Scene
 from .input_map import InputManager
 from . import sfx
-from .ui.widgets import (
+import client.ui.widgets as uiw
+from client.ui.widgets import (
     Button,
     Dropdown,
     RebindButton,
@@ -27,7 +28,6 @@ from .ui.widgets import (
     Label,
     Tooltip,
     Toast,
-    hover_hints,
 )
 from .ui.theme import set_theme
 
@@ -395,7 +395,7 @@ class SettingsScene(Scene):
             w.draw(surface)
             if hasattr(w, "tooltip") and w.rect.collidepoint(mouse_pos):
                 w.tooltip.draw(surface, (w.rect.right + 10, w.rect.y))
-        hover_hints.draw(surface)
+        uiw.hover_hints.draw(surface)
         y = 10
         for t in self.toasts:
             t.draw(surface, y)

--- a/src/client/ui/widgets.py
+++ b/src/client/ui/widgets.py
@@ -21,7 +21,8 @@ from ..input_map import InputManager, name_for_key
 _font: pygame.font.Font | None = None
 _fonts: dict[int, pygame.font.Font] = {}
 _default_size = 0
-hover_hints: List[str] = []  # filled by tests; mirrors real project
+hover_hints: "HoverHints" | None = None
+help_hints: List[str] = []  # filled by tests; mirrors real project
 
 
 # ---------------------------------------------------------------------------
@@ -31,13 +32,14 @@ hover_hints: List[str] = []  # filled by tests; mirrors real project
 def init_ui(scale: float = 1.0) -> None:
     """Initialise pygame font subsystem and cache a default font."""
 
-    global _font, _fonts, _default_size
+    global _font, _fonts, _default_size, hover_hints
     if not pygame.font.get_init():  # pragma: no cover - defensive
         pygame.font.init()
     size = int(14 * max(1.0, min(scale, 2.0)))
     _font = pygame.font.SysFont(None, size)
     _fonts = {size: _font}
     _default_size = size
+    hover_hints = HoverHints()
 
 
 def _f(size: int | None = None) -> pygame.font.Font:
@@ -47,6 +49,27 @@ def _f(size: int | None = None) -> pygame.font.Font:
     if size not in _fonts:
         _fonts[size] = pygame.font.SysFont(None, size)
     return _fonts[size]
+
+
+class HoverHints:
+    """Tiny manager for floating hover hints."""
+
+    def __init__(self) -> None:
+        self.text: str | None = None
+        self.pos: tuple[int, int] = (0, 0)
+
+    def show(self, text: str, pos: tuple[int, int]) -> None:
+        self.text = text
+        self.pos = pos
+
+    def clear(self) -> None:
+        self.text = None
+
+    def draw(self, surf: pygame.Surface) -> None:
+        if not self.text:
+            return
+        img = _f().render(self.text, True, (255, 255, 255))
+        surf.blit(img, self.pos)
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +473,7 @@ class HelpOverlay:
     def draw(self, surf: pygame.Surface) -> None:  # pragma: no cover - visual
         if not self.visible:
             return
-        lines = hover_hints or []
+        lines = help_hints or []
         y = 10
         for line in lines:
             img = _f().render(line, True, (255, 255, 255))
@@ -604,4 +627,5 @@ __all__ = [
     "Minimap",
     "MinimapWidget",
     "hover_hints",
+    "help_hints",
 ]

--- a/tests/test_hover_hints_shadow.py
+++ b/tests/test_hover_hints_shadow.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pathlib
+
+import pygame
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(ROOT), str(ROOT / "src")])
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+pygame.init()
+pygame.font.init()
+
+import client.ui.widgets as uiw  # noqa: E402  pylint: disable=wrong-import-position
+from client.ui.widgets import HoverHints  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_hover_hints_shadow() -> None:
+    uiw.init_ui()
+    hints_list = []  # local variable should not shadow uiw.hover_hints
+    surf = pygame.Surface((10, 10))
+    uiw.hover_hints.show("tip", (0, 0))
+    uiw.hover_hints.draw(surf)
+    assert isinstance(uiw.hover_hints, HoverHints)

--- a/tests/test_settings_scene.py
+++ b/tests/test_settings_scene.py
@@ -14,14 +14,13 @@ pygame.font.init()
 
 from client import scene_settings  # noqa: E402  pylint: disable=wrong-import-position
 from client.ui import widgets  # noqa: E402  pylint: disable=wrong-import-position
-from client.input import InputManager  # noqa: E402  pylint: disable=wrong-import-position
+from client.input_map import InputManager  # noqa: E402  pylint: disable=wrong-import-position
 
 
 def test_settings_scene(monkeypatch) -> None:
     widgets.init_ui()
     monkeypatch.setattr(scene_settings.gconfig, "save_config", lambda cfg: None)
     monkeypatch.setattr(scene_settings.gconfig, "DEFAULT_SAVE_CONFLICT_POLICY", "ask", False)
-    scene_settings.hover_hints = SimpleNamespace(draw=lambda _surf: None)
 
     cfg: dict[str, object] = {
         "ui_theme": "dark",
@@ -29,7 +28,8 @@ def test_settings_scene(monkeypatch) -> None:
         "ui_scale": 1.0,
         "large_text": False,
     }
-    app = SimpleNamespace(cfg=cfg, input=InputManager(cfg), screen=pygame.display.set_mode((640, 480)))
+    input_mgr = InputManager.from_config(cfg.get("keybinds"))
+    app = SimpleNamespace(cfg=cfg, input=input_mgr, screen=pygame.display.set_mode((640, 480)))
     scene = scene_settings.SettingsScene(app)
 
     surface = pygame.Surface((640, 480))

--- a/tests/test_ui_smoke.py
+++ b/tests/test_ui_smoke.py
@@ -19,7 +19,7 @@ from gamecore import board as gboard
 
 def test_ui_smoke() -> None:
     widgets.init_ui()
-    widgets.hover_hints[:] = ["h1", "h2"]
+    widgets.help_hints[:] = ["h1", "h2"]
 
     app = App({})
     scene = GameScene(app, new_game=True)


### PR DESCRIPTION
## Summary
- Avoid local hover hint collisions by importing widgets via namespace and renaming scene lists
- Implement `HoverHints` singleton and expose `help_hints` list in widget module
- Add regression test ensuring local hint lists do not shadow UI singleton

## Testing
- ✅ `pytest tests/test_hover_hints_shadow.py tests/test_ui_smoke.py tests/test_settings_scene.py -q`
- ⚠️ `pytest -q` *(fails: module 'gamecore.board' has no attribute 'export_map', missing features in stubs)*

------
https://chatgpt.com/codex/tasks/task_e_689db2e3a15c8329982d7ffd1cf6cb44