### PR TITLE
Add functional enemy system and campaign persistence

### DIFF
--- a/src/enemies.py
+++ b/src/enemies.py
@@ -1,1 +1,134 @@
-[см. предыдущие ответы — с поддержкой промаха в дыму и обработки токенов]
+"""Enemy and status effect logic used by the text based game.
+
+This repository originally shipped without a functional implementation of
+enemies which made running the interactive game impossible.  The module
+below provides a small yet complete version of the original idea.  It is
+intended to be simple so that it can be easily unit tested and serialised
+when saving the game state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class StatusEffect:
+    """Represents a temporary effect that can be applied to the player."""
+
+    effect_type: str
+    duration: int
+
+    def to_dict(self) -> dict:
+        return {"effect_type": self.effect_type, "duration": self.duration}
+
+    @staticmethod
+    def from_dict(data: dict) -> "StatusEffect":
+        return StatusEffect(data["effect_type"], int(data["duration"]))
+
+
+class Enemy:
+    """A very small enemy implementation.
+
+    Each enemy knows its position, amount of health and the damage of its
+    basic attack.  Enemies can move towards the player and attack him.  With
+    a small chance the attack applies a ``poison`` status effect which is
+    also returned to the caller so that the user interface can notify the
+    player.
+    """
+
+    def __init__(self, pos: Tuple[int, int], health: int = 3, attack: int = 1):
+        self.pos = pos
+        self.health = health
+        self.attack_damage = attack
+
+    # ------------------------------------------------------------------
+    def move_towards(self, target: Tuple[int, int], width: int, height: int, steps: int = 1) -> None:
+        """Move the enemy towards ``target`` by ``steps`` tiles."""
+
+        x, y = self.pos
+        tx, ty = target
+        for _ in range(steps):
+            if x < tx:
+                x += 1
+            elif x > tx:
+                x -= 1
+            elif y < ty:
+                y += 1
+            elif y > ty:
+                y -= 1
+        self.pos = (max(0, min(width - 1, x)), max(0, min(height - 1, y)))
+
+    def perform_attack(self, campaign) -> Optional[StatusEffect]:
+        """Deal damage to the campaign's player and maybe return an effect."""
+
+        campaign.player.damage(self.attack_damage)
+        # To keep the game interesting there is a small chance to apply a
+        # poison effect.  The random module is used directly so unit tests can
+        # control the outcome by seeding it.
+        if random.random() < 0.30:
+            effect = StatusEffect("poison", duration=3)
+            campaign.status_effects.append(effect)
+            return effect
+        return None
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict:
+        return {"pos": self.pos, "health": self.health, "attack": self.attack_damage}
+
+    @staticmethod
+    def from_dict(data: dict) -> "Enemy":
+        return Enemy(tuple(data["pos"]), data.get("health", 3), data.get("attack", 1))
+
+
+class EnemyManager:
+    """Container handling a collection of :class:`Enemy` objects."""
+
+    def __init__(self, enemies: List[Enemy]):
+        self.enemies = enemies
+
+    # factory -----------------------------------------------------------
+    @staticmethod
+    def spawn_on_map(width: int, height: int, count: int, player_pos: Tuple[int, int]) -> "EnemyManager":
+        """Spawn ``count`` enemies on random positions of the map."""
+
+        positions = {player_pos}
+        enemies: List[Enemy] = []
+        while len(enemies) < count:
+            x, y = random.randint(0, width - 1), random.randint(0, height - 1)
+            if (x, y) in positions:
+                continue
+            enemies.append(Enemy((x, y)))
+            positions.add((x, y))
+        return EnemyManager(enemies)
+
+    # update ------------------------------------------------------------
+    def move_towards_player(self, player_pos: Tuple[int, int], width: int, height: int, campaign=None) -> None:
+        """Move all enemies towards the player.
+
+        Enemies become more aggressive at night and therefore move two tiles
+        instead of one.  Only the ``time_of_day`` attribute of ``campaign`` is
+        inspected which keeps the interface minimal.
+        """
+
+        steps = 2 if campaign and getattr(campaign, "time_of_day", "day") == "night" else 1
+        for enemy in self.enemies:
+            enemy.move_towards(player_pos, width, height, steps)
+
+    def get_enemy_at(self, pos: Tuple[int, int]) -> Optional[Enemy]:
+        for enemy in self.enemies:
+            if enemy.pos == pos:
+                return enemy
+        return None
+
+    # serialisation -----------------------------------------------------
+    def to_dict(self) -> dict:
+        return {"enemies": [e.to_dict() for e in self.enemies]}
+
+    @staticmethod
+    def from_dict(data: dict) -> "EnemyManager":
+        enemies = [Enemy.from_dict(d) for d in data.get("enemies", [])]
+        return EnemyManager(enemies)
+

--- a/test_campaign_save_load.py
+++ b/test_campaign_save_load.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from campaign import Campaign
+from enemies import EnemyManager, Enemy
+from game_map import GameMap
+from inventory import Inventory
+from player import Player
+
+
+def test_campaign_can_be_saved_and_loaded(tmp_path):
+    gm = GameMap(4, 4, player_pos=(1, 1))
+    inv = Inventory({"еда": 2}, coins=5)
+    player = Player(health=4, max_health=5)
+    enemies = EnemyManager([Enemy((2, 2))])
+
+    camp = Campaign(
+        [],
+        game_map=gm,
+        inventory=inv,
+        player=player,
+        enemies=enemies,
+        turn_count=3,
+        time_of_day="night",
+    )
+
+    path = tmp_path / "save.json"
+    camp.save(path)
+
+    loaded = Campaign.load(path, [])
+
+    assert loaded.game_map.player_pos == (1, 1)
+    assert loaded.inventory.coins == 5
+    assert loaded.player.health == 4
+    assert loaded.time_of_day == "night"
+    assert loaded.turn_count == 3
+

--- a/test_enemy_logic.py
+++ b/test_enemy_logic.py
@@ -1,0 +1,33 @@
+import random
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from enemies import Enemy, EnemyManager
+from campaign import Campaign
+from game_map import GameMap
+from player import Player
+
+
+def test_enemy_moves_faster_at_night_and_attacks():
+    random.seed(0)
+    gm = GameMap(5, 5, player_pos=(0, 0))
+    player = Player(health=5, max_health=5)
+    enemy = Enemy((3, 0), attack=2)
+    manager = EnemyManager([enemy])
+    camp = Campaign([], game_map=gm, player=player, enemies=manager)
+
+    # day movement – one tile towards player
+    manager.move_towards_player(gm.player_pos, gm.width, gm.height, camp)
+    assert enemy.pos == (2, 0)
+
+    # night movement – two tiles
+    camp.time_of_day = "night"
+    manager.move_towards_player(gm.player_pos, gm.width, gm.height, camp)
+    assert enemy.pos == (0, 0)
+
+    # enemy attacks and deals damage
+    enemy.perform_attack(camp)
+    assert camp.player.health == 3  # took 2 damage
+


### PR DESCRIPTION
## Summary
- implement basic `StatusEffect`, `Enemy` and `EnemyManager` with movement, attack and serialisation
- extend `Campaign` with player state and save/load helpers
- add playable text-based game loop that ties modules together
- cover enemy movement/attack and campaign persistence with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de114cdb48329ac5022a88c6f2d4d