### PR TITLE
Add GameBoard class with board manipulation and display

### DIFF
--- a/src/game_board.py
+++ b/src/game_board.py
@@ -1,0 +1,68 @@
+class GameBoard:
+    """Simple grid-based game board.
+
+    The board is represented by a two-dimensional list where each entry
+    holds the entity occupying the tile or ``None`` if the tile is empty.
+    Entities are expected to be represented by a single-character string
+    such as ``"P"`` for the player or ``"Z"`` for a zombie. The class
+    provides helpers to place and remove entities as well as query tile
+    status and produce a text representation of the board.
+    """
+
+    def __init__(self, width: int = 10, height: int = 10):
+        self.width = width
+        self.height = height
+        # initialise grid of None
+        self.grid = [[None for _ in range(width)] for _ in range(height)]
+
+    # ---------------------------------------------------------------
+    # Tile helpers
+    # ---------------------------------------------------------------
+    def within_bounds(self, x: int, y: int) -> bool:
+        """Return ``True`` if the coordinates are inside the board."""
+        return 0 <= x < self.width and 0 <= y < self.height
+
+    def is_tile_free(self, x: int, y: int) -> bool:
+        """Return ``True`` if the tile is inside bounds and unoccupied."""
+        return self.within_bounds(x, y) and self.grid[y][x] is None
+
+    # ---------------------------------------------------------------
+    # Manipulation
+    # ---------------------------------------------------------------
+    def place_entity(self, x: int, y: int, entity: str) -> None:
+        """Place ``entity`` on the given tile.
+
+        ``entity`` is typically a single character describing the occupant.
+        Raises ``ValueError`` if the position is out of bounds or the tile
+        is already occupied.
+        """
+        if not self.within_bounds(x, y):
+            raise ValueError("Position out of bounds")
+        if not self.is_tile_free(x, y):
+            raise ValueError("Tile is already occupied")
+        self.grid[y][x] = entity
+
+    def remove_entity(self, x: int, y: int) -> None:
+        """Remove any entity from the tile at ``(x, y)``.
+
+        Raises ``ValueError`` if the coordinates are outside the board.
+        """
+        if not self.within_bounds(x, y):
+            raise ValueError("Position out of bounds")
+        self.grid[y][x] = None
+
+    # ---------------------------------------------------------------
+    # Display helpers
+    # ---------------------------------------------------------------
+    def display_board(self) -> str:
+        """Return an ASCII representation of the board.
+
+        Empty tiles are rendered as ``.`` while occupied tiles use the
+        string representation of the stored entity. The board is returned
+        as a multi-line string with each row separated by a newline.
+        """
+        lines = []
+        for row in self.grid:
+            line = ''.join(cell if cell is not None else '.' for cell in row)
+            lines.append(line)
+        return '\n'.join(lines)

--- a/test_game_board.py
+++ b/test_game_board.py
@@ -1,0 +1,37 @@
+import pytest
+from src.game_board import GameBoard
+
+
+def test_default_size_and_free_tiles():
+    board = GameBoard()
+    assert board.width == 10 and board.height == 10
+    # all tiles should be free at start
+    for x in range(board.width):
+        for y in range(board.height):
+            assert board.is_tile_free(x, y)
+
+
+def test_place_and_remove_entity():
+    board = GameBoard(5, 5)
+    board.place_entity(1, 1, 'P')
+    assert not board.is_tile_free(1, 1)
+    board.remove_entity(1, 1)
+    assert board.is_tile_free(1, 1)
+
+
+def test_bounds_and_errors():
+    board = GameBoard(3, 3)
+    with pytest.raises(ValueError):
+        board.place_entity(3, 0, 'P')
+    with pytest.raises(ValueError):
+        board.remove_entity(-1, 0)
+    assert not board.within_bounds(3, 3)
+    assert board.is_tile_free(3, 3) is False
+
+
+def test_display_board():
+    board = GameBoard(3, 2)
+    board.place_entity(0, 0, 'P')
+    board.place_entity(1, 0, 'Z')
+    expected = "PZ.\n..."
+    assert board.display_board() == expected


### PR DESCRIPTION
## Summary
- Implement `GameBoard` for grid management, including bounds checks, entity placement/removal, and ASCII rendering.
- Add tests verifying default size, tile occupancy, boundary checks, and display output.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1b6c39c48329b3f0570b2a9f467b