### PR TITLE
Add turn order manager with round tracking

### DIFF
--- a/src/turn_manager.py
+++ b/src/turn_manager.py
@@ -1,44 +1,120 @@
-class TurnManager:
-    """
-    Управление фазами хода и очками действий (AP) — делает игру ближе к настольной.
-    Фазы: Event -> Action -> Enemy -> Cleanup
-    """
-    PHASES = ["event", "action", "enemy", "cleanup"]
+"""Utilities to handle turn order and rounds.
 
-    def __init__(self, ap_per_turn: int = 3):
-        self.current_phase_index = 0
-        self.ap_per_turn = ap_per_turn
-        self.remaining_ap = ap_per_turn
-        self.turn_number = 0
+The original project only contained a very small stub for a turn manager
+focussed on action points and phases.  For the tests and future gameplay we
+require a component that can cycle through a list of participants (players or
+enemies) and keep track of rounds.  Each participant receives a random number
+of actions at the beginning of their turn.
+
+The implementation below intentionally stays lightweight.  It stores a list of
+participants and exposes :meth:`start_turn` and :meth:`end_turn` helpers.  The
+former rolls a six sided die to determine how many actions the current
+participant gets.  :meth:`end_turn` advances to the next participant and
+increments the round counter once every participant has acted.  A placeholder
+hook :meth:`handle_end_of_round` is provided for future extensions such as
+event triggering.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Tuple, Any
+
+import dice
+
+
+class TurnManager:
+    """Manage turn order for a list of participants.
+
+    Parameters
+    ----------
+    participants:
+        Iterable of objects representing the actors that take turns.  The
+        objects are kept as-is which makes the manager agnostic of the actual
+        player or enemy implementation.
+    """
+
+    def __init__(self, participants: Iterable[Any]):
+        participants = list(participants)
+        if not participants:
+            raise ValueError("TurnManager requires at least one participant")
+        self._participants: List[Any] = participants
+        self._index: int = 0
+        self.round: int = 1
+        self.actions_left: int = 0
+
+    # ------------------------------------------------------------------
+    # helper properties
+    @property
+    def participants(self) -> List[Any]:
+        """Return the list of managed participants."""
+
+        return self._participants
 
     @property
-    def current_phase(self) -> str:
-        return self.PHASES[self.current_phase_index]
+    def current_player(self) -> Any:
+        """Return the participant whose turn it is currently."""
 
-    def start_turn(self):
-        self.turn_number += 1
-        self.current_phase_index = 0
-        self.remaining_ap = self.ap_per_turn
-        return self.current_phase
+        return self._participants[self._index]
 
-    def next_phase(self):
-        if self.current_phase_index < len(self.PHASES) - 1:
-            self.current_phase_index += 1
-        else:
-            self.start_turn()
-        return self.current_phase
+    # ------------------------------------------------------------------
+    # turn handling
+    def start_turn(self, player: Optional[Any] = None) -> Tuple[Any, int]:
+        """Start a turn for ``player`` and roll their action points.
 
-    def use_ap(self, amount: int = 1) -> bool:
-        if self.remaining_ap >= amount:
-            self.remaining_ap -= amount
-            return True
-        return False
+        Parameters
+        ----------
+        player:
+            Optional participant to start the turn for.  If omitted the current
+            participant is used.  Passing an explicit participant also makes
+            them the current one.
 
-    def has_ap(self) -> bool:
-        return self.remaining_ap > 0
+        Returns
+        -------
+        tuple
+            ``(player, actions)`` where ``actions`` is the number of actions
+            rolled for this turn.
+        """
 
-    def set_ap(self, value: int):
-        self.remaining_ap = value
+        if player is not None:
+            try:
+                self._index = self._participants.index(player)
+            except ValueError:  # pragma: no cover - defensive programming
+                raise ValueError("Unknown participant") from None
 
-    def __str__(self):
-        return f"Turn {self.turn_number} | Phase: {self.current_phase} | AP: {self.remaining_ap}/{self.ap_per_turn}"
+        player = self.current_player
+        self.actions_left, _ = dice.roll("1d6")
+        return player, self.actions_left
+
+    def end_turn(self) -> Any:
+        """Finish the current participant's turn and move to the next one.
+
+        When the last participant ends their turn the round counter is
+        increased and :meth:`handle_end_of_round` is invoked.
+
+        Returns
+        -------
+        object
+            The participant whose turn is next.
+        """
+
+        self._index += 1
+        if self._index >= len(self._participants):
+            self._index = 0
+            self.round += 1
+            self.handle_end_of_round()
+        return self.current_player
+
+    # ------------------------------------------------------------------
+    def handle_end_of_round(self) -> None:  # pragma: no cover - placeholder
+        """Hook for end-of-round logic.
+
+        Sub-classes may override this method to implement features such as
+        event triggering or status effect handling.  The default implementation
+        intentionally does nothing.
+        """
+
+        return None
+
+
+__all__ = ["TurnManager"]
+

--- a/test_turn_manager.py
+++ b/test_turn_manager.py
@@ -1,0 +1,41 @@
+"""Tests for the :mod:`turn_manager` module."""
+
+from typing import Any
+
+import turn_manager
+
+
+class Dummy:
+    """Very small stand-in for a player or enemy."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def test_start_turn_rolls_actions(monkeypatch):
+    players = [Dummy("p1")]
+    tm = turn_manager.TurnManager(players)
+
+    # Ensure deterministic dice results.
+    monkeypatch.setattr(turn_manager.dice, "roll", lambda _: (4, ""))
+
+    player, actions = tm.start_turn()
+    assert player is players[0]
+    assert actions == 4
+    assert tm.actions_left == 4
+
+
+def test_round_progression(monkeypatch):
+    players = [Dummy("p1"), Dummy("p2")]
+    tm = turn_manager.TurnManager(players)
+
+    monkeypatch.setattr(turn_manager.dice, "roll", lambda _: (1, ""))
+
+    tm.start_turn()  # p1
+    tm.end_turn()    # switch to p2
+    tm.start_turn()  # p2
+    tm.end_turn()    # new round, back to p1
+
+    assert tm.round == 2
+    assert tm.current_player is players[0]
+


### PR DESCRIPTION
## Summary
- replace stubbed turn manager with participant-based implementation
- support die-rolled actions and round progression
- add unit tests for turn sequencing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1c6989d483299d5716cd01076aa7