### PR TITLE
Add basic random event deck system

### DIFF
--- a/src/event_deck.py
+++ b/src/event_deck.py
@@ -1,8 +1,181 @@
-    def apply(self, campaign):
-        eff = self.effect
-        # ... предыдущие
-        if "status" in eff:
-            from enemies import StatusEffect
-            st = eff["status"]
-            campaign.apply_status(StatusEffect(st["effect_type"], st["duration"]))
-            print(f"Получен эффект: {st['effect_type'].upper()} на {st['duration']} ходов")
+"""Simple random event system for the board game.
+
+The original project this repository stems from featured a rather involved
+event system driven by JSON data.  For the purposes of the unit tests in this
+kata we provide a much smaller yet fully functional implementation.  Each
+event carries a short description and a callable effect which manipulates the
+current game state.  A small deck of sample events is included to demonstrate
+how events may influence the board and players.
+
+Events are deliberately lightweight and self‑contained which makes them easy to
+extend in the future – simply create a new :class:`Event` instance and add it to
+the deck.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from game_board import GameBoard
+from player import Player
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GameState:
+    """Minimal representation of the game's mutable state.
+
+    The production project exposes a very feature rich state object.  For the
+    tests we only require a board, a list of players, optional item locations
+    and coordinates of existing zombies.  The structure is intentionally kept
+    simple so it can easily be instantiated by the tests.
+    """
+
+    board: GameBoard
+    players: List[Player]
+    items: Dict[Tuple[int, int], str] = field(default_factory=dict)
+    zombies: List[Tuple[int, int]] = field(default_factory=list)
+
+
+@dataclass
+class Event:
+    """Representation of a single random event.
+
+    Parameters
+    ----------
+    description:
+        Human readable explanation of the event.
+    effect:
+        Callable which mutates the provided :class:`GameState`.
+    """
+
+    description: str
+    effect: Callable[[GameState], None]
+
+    def apply(self, game_state: GameState) -> None:
+        """Execute the event's effect on ``game_state``."""
+
+        self.effect(game_state)
+
+
+@dataclass
+class EventDeck:
+    """Container holding a set of events.
+
+    The :meth:`draw` method selects a random event, applies it and returns the
+    chosen instance.  Using a dedicated class keeps the implementation flexible
+    and mirrors a draw pile of physical cards.
+    """
+
+    events: List[Event]
+
+    def draw(self, game_state: GameState) -> Event:
+        """Pick a random event from the deck and apply it.
+
+        Parameters
+        ----------
+        game_state:
+            The current state to which the event's effect will be applied.
+
+        Returns
+        -------
+        Event
+            The event that was drawn and executed.
+        """
+
+        event = random.choice(self.events)
+        event.apply(game_state)
+        return event
+
+
+# ---------------------------------------------------------------------------
+# Event effect helpers
+# ---------------------------------------------------------------------------
+
+
+def _zombie_horde_effect(game_state: GameState) -> None:
+    """Spawn one to three zombies at random free tiles."""
+
+    count = random.randint(1, 3)
+    placed = 0
+    attempts = 0
+    while placed < count and attempts < 100:
+        x = random.randrange(game_state.board.width)
+        y = random.randrange(game_state.board.height)
+        if game_state.board.is_tile_free(x, y):
+            game_state.board.place_entity(x, y, "Z")
+            game_state.zombies.append((x, y))
+            placed += 1
+        attempts += 1
+
+
+def _supply_drop_effect(game_state: GameState) -> None:
+    """Place a random item on a random free tile."""
+
+    item = random.choice(["food", "ammo", "medkit"])
+    attempts = 0
+    while attempts < 100:
+        x = random.randrange(game_state.board.width)
+        y = random.randrange(game_state.board.height)
+        if game_state.board.is_tile_free(x, y) and (x, y) not in game_state.items:
+            game_state.items[(x, y)] = item
+            break
+        attempts += 1
+
+
+def _ambush_effect(game_state: GameState) -> None:
+    """All players take one point of damage."""
+
+    for player in game_state.players:
+        player.take_damage(1)
+
+
+# ---------------------------------------------------------------------------
+# Default deck and drawing helper
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_DECK = EventDeck(
+    [
+        Event("Zombie Horde", _zombie_horde_effect),
+        Event("Supply Drop", _supply_drop_effect),
+        Event("Ambush", _ambush_effect),
+    ]
+)
+
+
+def draw_event(
+    game_state: GameState, deck: Optional[Sequence[Event]] = None
+) -> Event:
+    """Select a random :class:`Event` from ``deck`` and apply it.
+
+    Parameters
+    ----------
+    game_state:
+        The mutable game state to be altered by the event.
+    deck:
+        Optional sequence of events to draw from.  When omitted the
+        :data:`DEFAULT_DECK` is used.
+    """
+
+    if deck is None:
+        deck = DEFAULT_DECK.events
+    event = random.choice(list(deck))
+    event.apply(game_state)
+    return event
+
+
+__all__ = [
+    "GameState",
+    "Event",
+    "EventDeck",
+    "DEFAULT_DECK",
+    "draw_event",
+]
+

--- a/test_event_deck.py
+++ b/test_event_deck.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import random
+
+
+# Ensure the ``src`` directory is importable when tests are executed from the
+# repository root.  This mirrors the approach used in the existing test suite.
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from event_deck import (
+    DEFAULT_DECK,
+    Event,
+    EventDeck,
+    GameState,
+    draw_event,
+)
+from game_board import GameBoard
+from player import Player
+
+
+def _get_event(description: str) -> Event:
+    """Return the event with ``description`` from the default deck."""
+
+    for ev in DEFAULT_DECK.events:
+        if ev.description == description:
+            return ev
+    raise AssertionError(f"Event {description!r} not found in deck")
+
+
+def test_zombie_horde_spawns_between_one_and_three_zombies():
+    board = GameBoard(5, 5)
+    state = GameState(board, [])
+    event = _get_event("Zombie Horde")
+    random.seed(0)
+    event.apply(state)
+
+    # Count zombies on the board
+    zombies = [
+        (x, y)
+        for y, row in enumerate(board.grid)
+        for x, cell in enumerate(row)
+        if cell == "Z"
+    ]
+    assert 1 <= len(zombies) <= 3
+    # The GameState keeps track of spawned zombies as well
+    assert zombies == state.zombies
+
+
+def test_ambush_damages_all_players():
+    board = GameBoard(3, 3)
+    p1 = Player(0, 0, health=5)
+    p2 = Player(1, 1, health=4)
+    state = GameState(board, [p1, p2])
+    event = _get_event("Ambush")
+    event.apply(state)
+    assert p1.health == 4
+    assert p2.health == 3
+
+
+def test_draw_event_uses_provided_deck():
+    board = GameBoard(3, 3)
+    player = Player(0, 0, health=5)
+    state = GameState(board, [player])
+    # Create a deck containing only the ambush event to make the draw deterministic
+    ambush = _get_event("Ambush")
+    deck = EventDeck([ambush])
+    drawn = draw_event(state, deck.events)
+    assert drawn.description == "Ambush"
+    assert player.health == 4
+


### PR DESCRIPTION
## Summary
- implement GameState, Event, and EventDeck classes for simple event handling
- add Zombie Horde, Supply Drop, and Ambush events
- provide draw_event helper and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e24a99e548329a1dfd3f8c5c8e580