### PR TITLE
Implement async GameClient and interaction test

### DIFF
--- a/src/game_client.py
+++ b/src/game_client.py
@@ -1,0 +1,150 @@
+import asyncio
+import json
+import contextlib
+from typing import Dict, Any
+
+from game_board import GameBoard
+
+
+class GameClient:
+    """Async client used by players to talk to :class:`GameServer`.
+
+    The client is intentionally thin – it connects to the server, sends
+    high level player commands and keeps a local representation of the
+    game state based on updates received from the server.  Communication
+    happens via newline separated JSON messages.
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 9999,
+        *,
+        reconnect_attempts: int = 3,
+        reconnect_delay: float = 0.5,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.reconnect_attempts = reconnect_attempts
+        self.reconnect_delay = reconnect_delay
+
+        self.reader: asyncio.StreamReader | None = None
+        self.writer: asyncio.StreamWriter | None = None
+        self.listen_task: asyncio.Task | None = None
+        self.connected: bool = False
+
+        # local representation of the game state
+        self.board = GameBoard()
+        self.players: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    async def connect(self) -> None:
+        """Connect to the server and start listening for updates."""
+
+        for attempt in range(self.reconnect_attempts + 1):
+            try:
+                self.reader, self.writer = await asyncio.open_connection(
+                    self.host, self.port
+                )
+                self.connected = True
+                self.listen_task = asyncio.create_task(self._listen())
+                return
+            except (OSError, ConnectionRefusedError):
+                self.connected = False
+                if attempt >= self.reconnect_attempts:
+                    raise
+                await asyncio.sleep(self.reconnect_delay)
+
+    async def _listen(self) -> None:
+        assert self.reader is not None
+        try:
+            while True:
+                line = await self.reader.readline()
+                if not line:
+                    break
+                try:
+                    state = json.loads(line.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+                self._apply_state(state)
+        finally:
+            self.connected = False
+            # best effort reconnect
+            if self.reconnect_attempts > 0:
+                for _ in range(self.reconnect_attempts):
+                    try:
+                        await asyncio.sleep(self.reconnect_delay)
+                        await self.connect()
+                        return
+                    except Exception:
+                        continue
+
+    # ------------------------------------------------------------------
+    def _apply_state(self, state: Dict[str, Any]) -> None:
+        """Update local game state from ``state`` received from server."""
+
+        board = state.get("board")
+        if isinstance(board, str):
+            rows = board.splitlines()
+            self.board.height = len(rows)
+            self.board.width = len(rows[0]) if rows else 0
+            self.board.grid = [
+                [None if ch == "." else ch for ch in row] for row in rows
+            ]
+
+        players = state.get("players")
+        if isinstance(players, dict):
+            self.players = players
+
+    # ------------------------------------------------------------------
+    async def send_action(self, action: Dict[str, Any]) -> None:
+        """Send ``action`` dictionary to the server."""
+
+        if not self.connected or self.writer is None:
+            raise ConnectionError("Not connected to server")
+        data = json.dumps(action).encode("utf-8") + b"\n"
+        self.writer.write(data)
+        await self.writer.drain()
+
+    async def move(self, dx: int, dy: int) -> None:
+        await self.send_action({"action": "move", "dx": dx, "dy": dy})
+
+    async def attack(self, x: int, y: int) -> None:
+        await self.send_action({"action": "attack", "x": x, "y": y})
+
+    async def command(self, text: str) -> None:
+        """Parse a textual ``text`` command and send the appropriate action."""
+
+        parts = text.strip().split()
+        if not parts:
+            return
+        cmd = parts[0].lower()
+        if cmd == "move" and len(parts) == 2:
+            direction = parts[1].lower()
+            mapping = {"north": (0, -1), "south": (0, 1), "east": (1, 0), "west": (-1, 0)}
+            if direction in mapping:
+                dx, dy = mapping[direction]
+                await self.move(dx, dy)
+        elif cmd == "attack" and len(parts) == 3:
+            try:
+                x, y = int(parts[1]), int(parts[2])
+            except ValueError:
+                return
+            await self.attack(x, y)
+
+    # ------------------------------------------------------------------
+    async def close(self) -> None:
+        """Close the connection to the server."""
+
+        if self.listen_task:
+            self.listen_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.listen_task
+        if self.writer is not None:
+            self.writer.close()
+            with contextlib.suppress(Exception):
+                await self.writer.wait_closed()
+        self.connected = False
+
+
+__all__ = ["GameClient"]

--- a/test_game_client.py
+++ b/test_game_client.py
@@ -1,0 +1,46 @@
+import asyncio
+import contextlib
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
+
+from game_server import GameServer
+from game_client import GameClient
+
+
+def _run_server(port_holder):
+    server = GameServer(port=0)
+
+    async def run():
+        srv = await asyncio.start_server(server.handle_client, server.host, 0)
+        server._server = srv
+        port_holder.append(srv.sockets[0].getsockname()[1])
+        async with srv:
+            await srv.serve_forever()
+
+    return run()
+
+
+def test_client_server_interaction():
+    port_holder: list[int] = []
+    server_coro = _run_server(port_holder)
+
+    async def runner():
+        server_task = asyncio.create_task(server_coro)
+        while not port_holder:
+            await asyncio.sleep(0.01)
+        port = port_holder[0]
+        client = GameClient(port=port)
+        await client.connect()
+        # wait for initial state from server
+        await asyncio.sleep(0.05)
+        await client.move(1, 0)
+        await asyncio.sleep(0.1)
+        assert client.board.grid[0][1] == "P"
+        await client.close()
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- Add asyncio-based GameClient that connects to GameServer, sends commands, maintains local board state, and reconnects on disconnect
- Provide helper methods to move, attack, and parse text commands
- Include test ensuring GameClient updates its board from server updates

## Testing
- `pytest test_game_client.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame', 'gamecore', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e2a1ae3808329957108ef0b1cb341