### PR TITLE
Add achievement tracker system

### DIFF
--- a/src/achievement_tracker.py
+++ b/src/achievement_tracker.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Simple achievement tracking system.
+
+The tracker is notified about relevant game events and unlocks achievements
+when their conditions are met.  For now achievements are merely printed to the
+console, but :func:`unlock_achievement` is structured in a way so it can later
+be extended to integrate with the Steamworks API or similar services.
+"""
+
+from typing import Callable, Set
+
+# ---------------------------------------------------------------------------
+# Achievement identifiers
+FIRST_BLOOD = "First Blood"
+ZOMBIE_SLAYER = "Zombie Slayer"
+SURVIVOR = "Survivor"
+
+
+class AchievementTracker:
+    """Track and unlock achievements based on game events.
+
+    Parameters
+    ----------
+    notifier:
+        Optional callback that receives the name of an unlocked achievement.
+        When omitted a simple ``print`` based notifier is used.
+    """
+
+    def __init__(self, notifier: Callable[[str], None] | None = None) -> None:
+        self._notifier = notifier or (lambda name: print(f"Achievement Unlocked: {name}"))
+        self._unlocked: Set[str] = set()
+        self.zombie_kills: int = 0
+        self.players_dead: int = 0
+
+    # ------------------------------------------------------------------
+    # helpers
+    def unlock_achievement(self, name: str) -> None:
+        """Mark ``name`` as unlocked and notify once.
+
+        This function is the central place where integration with external
+        achievement providers would occur.
+        """
+
+        if name in self._unlocked:
+            return
+        self._unlocked.add(name)
+        self._notifier(name)
+
+    def is_unlocked(self, name: str) -> bool:
+        """Return ``True`` if ``name`` has already been unlocked."""
+
+        return name in self._unlocked
+
+    # ------------------------------------------------------------------
+    # event handlers
+    def on_zombie_kill(self) -> None:
+        """Handle the event of a zombie being killed."""
+
+        self.zombie_kills += 1
+        if self.zombie_kills == 1:
+            self.unlock_achievement(FIRST_BLOOD)
+        if self.zombie_kills >= 50:
+            self.unlock_achievement(ZOMBIE_SLAYER)
+
+    def on_player_death(self) -> None:
+        """Record that a player has died in the current scenario."""
+
+        self.players_dead += 1
+
+    def on_scenario_win(self) -> None:
+        """Handle the event of winning a scenario.
+
+        The ``SURVIVOR`` achievement is unlocked if no players died during the
+        scenario.  Player death counters are reset afterwards.
+        """
+
+        if self.players_dead == 0:
+            self.unlock_achievement(SURVIVOR)
+        self.players_dead = 0
+
+    # ------------------------------------------------------------------
+    def reset(self) -> None:
+        """Reset all internal counters and unlocked achievements."""
+
+        self.zombie_kills = 0
+        self.players_dead = 0
+        self._unlocked.clear()

--- a/test_achievement_tracker.py
+++ b/test_achievement_tracker.py
@@ -1,0 +1,30 @@
+from src.achievement_tracker import (
+    AchievementTracker,
+    FIRST_BLOOD,
+    ZOMBIE_SLAYER,
+    SURVIVOR,
+)
+
+
+def test_first_blood_and_zombie_slayer():
+    tracker = AchievementTracker()
+    tracker.on_zombie_kill()
+    assert tracker.is_unlocked(FIRST_BLOOD)
+    assert not tracker.is_unlocked(ZOMBIE_SLAYER)
+
+    for _ in range(49):
+        tracker.on_zombie_kill()
+    assert tracker.is_unlocked(ZOMBIE_SLAYER)
+
+
+def test_survivor_unlocked_when_no_deaths():
+    tracker = AchievementTracker()
+    tracker.on_scenario_win()
+    assert tracker.is_unlocked(SURVIVOR)
+
+
+def test_survivor_not_unlocked_when_player_dies():
+    tracker = AchievementTracker()
+    tracker.on_player_death()
+    tracker.on_scenario_win()
+    assert not tracker.is_unlocked(SURVIVOR)


### PR DESCRIPTION
## Summary
- add an `AchievementTracker` with callbacks for zombie kills, player deaths and scenario wins
- provide extensible `unlock_achievement` hook for future Steam integration
- include tests covering First Blood, Zombie Slayer and Survivor achievements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e3137447c83299cbf5e9aeb302655