### PR TITLE
Translate remaining Russian text to English

### DIFF
--- a/data/locales/en.json
+++ b/data/locales/en.json
@@ -48,5 +48,13 @@
   "settings.save_conflict.ask": "Ask every time",
   "settings.save_conflict.prefer_local": "Prefer local",
   "settings.save_conflict.prefer_cloud": "Prefer cloud",
-  "toast.settings_applied": "Settings applied"
+  "toast.settings_applied": "Settings applied",
+  "scenario_intro_name": "Introduction",
+  "scenario_intro_desc": "Get acquainted with the basics of survival on this board.",
+  "scenario_rescue_name": "Rescue the Survivors",
+  "scenario_rescue_desc": "Find and rescue all survivors on the map.",
+  "scenario_finale_name": "Final Battle",
+  "scenario_finale_desc": "Hold out against the final wave of enemies.",
+  "event_thirst_desc": "You feel extremely thirsty!",
+  "event_hunger_desc": "You are getting hungry!"
 }

--- a/data/locales/ru.json
+++ b/data/locales/ru.json
@@ -48,5 +48,13 @@
   "settings.save_conflict.ask": "Спрашивать каждый раз",
   "settings.save_conflict.prefer_local": "Предпочитать локальные",
   "settings.save_conflict.prefer_cloud": "Предпочитать облачные",
-  "toast.settings_applied": "Настройки применены"
+  "toast.settings_applied": "Настройки применены",
+  "scenario_intro_name": "Введение",
+  "scenario_intro_desc": "Ознакомьтесь с основами выживания на этом поле.",
+  "scenario_rescue_name": "Спасти выживших",
+  "scenario_rescue_desc": "Найдите и спасите всех выживших на карте.",
+  "scenario_finale_name": "Последний бой",
+  "scenario_finale_desc": "Удержитесь от финальной волны врагов.",
+  "event_thirst_desc": "Вас мучает сильная жажда!",
+  "event_hunger_desc": "Вы проголодались!"
 }

--- a/src/dice.py
+++ b/src/dice.py
@@ -5,18 +5,17 @@ from typing import Tuple
 DICE_RE = re.compile(r'^\s*(\d*)d(\d+)\s*([+-]\s*\d+)?\s*$')
 
 def roll(dice_notation: str) -> Tuple[int, str]:
-    """
-    Бросок кубиков по нотации NdM+K (например: "1d6", "2d8+1", "d6-1").
-    Возвращает (value, detail_string).
+    """Roll dice using NdM+K notation (e.g. "1d6", "2d8+1", "d6-1").
+    Returns a tuple of ``(value, detail_string)``.
     """
     m = DICE_RE.match(dice_notation)
     if not m:
-        # попытка разобрать простое число
+        # attempt to parse a plain number
         try:
             v = int(dice_notation.strip())
             return v, f"const {v}"
         except Exception:
-            raise ValueError(f"Неправильная нотация кубиков: '{dice_notation}'")
+            raise ValueError(f"Invalid dice notation: '{dice_notation}'")
     n_str, sides_str, mod_str = m.groups()
     n = int(n_str) if n_str else 1
     sides = int(sides_str)

--- a/src/events.json
+++ b/src/events.json
@@ -1,13 +1,12 @@
 [
     {
         "id": "thirst_event",
-        "description": "Вас мучает сильная жажда!",
+        "desc_key": "event_thirst_desc",
         "effect": { "status": { "effect_type": "thirst", "duration": 4 } }
     },
     {
         "id": "hunger_event",
-        "description": "Вы проголодались!",
+        "desc_key": "event_hunger_desc",
         "effect": { "status": { "effect_type": "hunger", "duration": 4 } }
     }
-    // ... остальные события
 ]

--- a/src/game_map.py
+++ b/src/game_map.py
@@ -8,7 +8,7 @@ class Zone:
         self.zone_type = zone_type  # 'resource', 'trap', 'event', 'quest', 'merchant', 'camp'
         self.explored = explored
         self.quest = quest
-        self.meta = meta or {}  # доп.данные: для merchant — инвентарь, для camp — уровень лагеря
+        self.meta = meta or {}  # extra data: for merchant — inventory, for camp — camp level
 
     def to_dict(self):
         return {
@@ -47,12 +47,12 @@ class GameMap:
                     meta = {}
                     if ztype == "merchant":
                         goods = {
-                            "еда": {"sell": 5, "buy": 2, "min_rep": 0},
-                            "вода": {"sell": 4, "buy": 2, "min_rep": 0},
-                            "бинты": {"sell": 8, "buy": 4, "min_rep": 0},
-                            "античный_артефакт": {"sell": 50, "buy": 20, "min_rep": 3}
+                            "food": {"sell": 5, "buy": 2, "min_rep": 0},
+                            "water": {"sell": 4, "buy": 2, "min_rep": 0},
+                            "bandages": {"sell": 8, "buy": 4, "min_rep": 0},
+                            "ancient_artifact": {"sell": 50, "buy": 20, "min_rep": 3}
                         }
-                        meta = {"goods": goods, "name": f"Торговец_{x}_{y}"}
+                        meta = {"goods": goods, "name": f"Trader_{x}_{y}"}
                     if ztype == "camp":
                         meta = {"level": 1}
                     zones.append(Zone((x, y), ztype, meta=meta))
@@ -105,16 +105,16 @@ class GameMap:
         )
 
     def __str__(self, enemies: Optional[list]=None, token_manager: Any = None):
-        """
-        Отрисовка карты в консоль.
-        Принимает список врагов и опционально token_manager для отображения символов токенов.
-        Логика отображения (при видимости):
-          - P  — игрок
-          - E  — враг
-          - <token_symbol> — символ токена (если нет персонажа на тайле)
+        """Render a text representation of the map.
+
+        Accepts a list of enemies and optionally a ``token_manager`` to show
+        token symbols. Rendering rules (for visible tiles):
+          - P  — player
+          - E  — enemy
+          - <token_symbol> — token symbol (if no character on the tile)
           - zone-dependent symbol ($ ^ ? Q M C)
-          - .  — пустая видимая клетка
-          - #  — скрытая клетка
+          - .  — empty visible cell
+          - #  — hidden cell
         """
         enemies = enemies or []
         enemy_positions = set(e.pos for e in enemies)

--- a/src/initiative.py
+++ b/src/initiative.py
@@ -1,1 +1,3 @@
-[см. предыдущие ответы — InitiativeCard/InitiativeDeck с эффектами, интеграция с кампанией и токенами]
+"""Placeholder for the initiative system."""
+
+# In this minimal codebase the initiative mechanics are not implemented.

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -67,33 +67,33 @@ class Inventory:
         """Use an item from the inventory and apply its effect to ``campaign``."""
 
         if not self.has_item(item_name):
-            return "Нет такого предмета в инвентаре."
+            return "No such item in inventory."
 
-        if item_name == "аптечка":
+        if item_name == "medkit":
             if campaign.player.health < campaign.player.max_health:
                 campaign.player.heal(3)
                 self.remove_item(item_name, 1)
-                return "Вы использовали аптечку и восстановили 3 здоровья."
-            return "У вас и так максимум здоровья."
+                return "You used a medkit and restored 3 health."
+            return "You already have maximum health."
 
-        if item_name == "еда":
+        if item_name == "food":
             before = len(campaign.status_effects)
             campaign.status_effects = [
                 e for e in campaign.status_effects if e.effect_type != "hunger"
             ]
             self.remove_item(item_name, 1)
             if len(campaign.status_effects) < before:
-                return "Вы поели и утолили голод."
-            return "Вы перекусили, но особых изменений не почувствовали."
+                return "You ate and satisfied your hunger."
+            return "You had a snack but feel no different."
 
-        if item_name == "вода":
+        if item_name == "water":
             campaign.status_effects = [
                 e for e in campaign.status_effects if e.effect_type != "thirst"
             ]
             self.remove_item(item_name, 1)
-            return "Вы утолили жажду."
+            return "You quenched your thirst."
 
-        if item_name == "противоядие":
+        if item_name == "antidote":
             removed = False
             for e in list(campaign.status_effects):
                 if e.effect_type == "poison":
@@ -101,10 +101,10 @@ class Inventory:
                     removed = True
             if removed:
                 self.remove_item(item_name, 1)
-                return "Вы приняли противоядие и избавились от яда."
-            return "Противоядие не требуется."
+                return "You took an antidote and cured the poison."
+            return "No antidote needed."
 
-        return "Этот предмет нельзя использовать напрямую."
+        return "This item cannot be used directly."
 
     def to_dict(self) -> Dict[str, Any]:
         return {"items": dict(self.items), "coins": self.coins}
@@ -115,10 +115,10 @@ class Inventory:
 
     def __str__(self) -> str:
         if not self.items and self.coins == 0:
-            return "Инвентарь пуст. Монет: 0"
+            return "Inventory empty. Coins: 0"
         parts = []
         if self.items:
             parts += [f"{item}: {qty}" for item, qty in self.items.items()]
-        parts.append(f"Монет: {self.coins}")
+        parts.append(f"Coins: {self.coins}")
         return "\n".join(parts)
 

--- a/src/journal.py
+++ b/src/journal.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from typing import List, Dict, Any
 
 class Journal:
-    """
-    Простой журнал (лог) для записей действий в партии.
-    Записи — словари: {time, turn, message}
+    """Simple log for recording actions during a session.
+
+    Entries are dictionaries: {time, turn, message}
     """
     def __init__(self, entries: List[Dict[str, Any]] = None):
         self.entries = entries or []

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from campaign import Campaign
 # ---------------------------------------------------------------------------
 # helper functions
 
+
 def _data_path(filename: str) -> str:
     """Return the absolute path to a data file located next to this module."""
 
@@ -33,16 +34,16 @@ def load_scenarios() -> List[dict]:
 
 def print_help() -> None:
     print(
-        "Команды: n/s/e/w – движение, map – карта, rest – отдых,\n"
-        "  trader – взаимодействие с торговцем, inv – инвентарь,\n"
-        "  save/load – сохранить или загрузить игру, quit – выход."
+        "Commands: n/s/e/w – move, map – map, rest – rest,\n",
+        "  trader – interact with trader, inv – inventory,\n",
+        "  save/load – save or load game, quit – exit."
     )
 
 
 def interact_with_trader(campaign: Campaign) -> None:
     trader = campaign.get_trader_at_player()
     if not trader:
-        print("Здесь нет торговца.")
+        print("There is no trader here.")
         return
     print(trader.list_goods(campaign))
     while True:
@@ -51,7 +52,7 @@ def interact_with_trader(campaign: Campaign) -> None:
             break
         parts = cmd.split()
         if len(parts) != 3:
-            print("Неверная команда.")
+            print("Invalid command.")
             continue
         action, item, qty = parts[0], parts[1], int(parts[2])
         if action == "buy":
@@ -59,7 +60,7 @@ def interact_with_trader(campaign: Campaign) -> None:
         elif action == "sell":
             print(trader.buy_from_player(item, campaign.inventory, qty, campaign))
         else:
-            print("Неизвестная команда.")
+            print("Unknown command.")
 
 
 # ---------------------------------------------------------------------------
@@ -73,10 +74,10 @@ def interact_with_trader(campaign: Campaign) -> None:
 # game loop
 
 def game_loop(campaign: Campaign) -> None:
-    print("Добро пожаловать в текстовую игру на выживание!")
+    print("Welcome to the text-based survival game!")
     print_help()
     while campaign.player.is_alive():
-        print(f"\nХод: {campaign.turn_count} | Время: {campaign.time_of_day}")
+        print(f"\nTurn: {campaign.turn_count} | Time: {campaign.time_of_day}")
         print(campaign.game_map.__str__(campaign.enemies.enemies))
         command = input("> ").strip().lower()
 
@@ -104,14 +105,14 @@ def game_loop(campaign: Campaign) -> None:
             continue
         elif command == "save":
             campaign.save(_data_path("savegame.json"))
-            print("Игра сохранена.")
+            print("Game saved.")
             continue
         elif command == "load":
             try:
                 campaign = Campaign.load(_data_path("savegame.json"), campaign.scenarios)
-                print("Загружено.")
+                print("Loaded.")
             except FileNotFoundError:
-                print("Сохранение не найдено.")
+                print("Save not found.")
             continue
         elif command == "help":
             print_help()
@@ -119,7 +120,7 @@ def game_loop(campaign: Campaign) -> None:
         elif command == "quit":
             break
         else:
-            print("Неизвестная команда. help – список команд.")
+            print("Unknown command. Type 'help' for a list of commands.")
             continue
 
         # ----- enemy phase -----
@@ -132,13 +133,13 @@ def game_loop(campaign: Campaign) -> None:
         enemy = campaign.enemies.get_enemy_at(campaign.game_map.player_pos)
         if enemy:
             effect = enemy.perform_attack(campaign)
-            print("Враг атакует вас!")
+            print("An enemy attacks you!")
             if effect:
-                print(f"Вы получили эффект: {effect.effect_type}")
+                print(f"You gained effect: {effect.effect_type}")
 
         campaign.tick_time()
 
-    print("Игра окончена.")
+    print("Game over.")
 
 
 def main_menu() -> None:
@@ -155,7 +156,7 @@ def main_menu() -> None:
         elif choice in {"2", "exit", "quit"}:
             break
         else:
-            print("Неизвестная команда. Выберите 1 или 2.")
+            print("Unknown command. Choose 1 or 2.")
 
 
 def main() -> None:
@@ -164,4 +165,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual execution only
     main()
-

--- a/src/main_board.py
+++ b/src/main_board.py
@@ -1,1 +1,4 @@
-[см. предыдущий ответ — здесь полный main_board.py]
+"""Placeholder module for the main_board implementation."""
+
+# The actual game board implementation is not required for the simplified
+# text-based example used in tests.

--- a/src/quest.py
+++ b/src/quest.py
@@ -1,7 +1,7 @@
-# ... предыдущий код класса Quest
+# ... previous Quest class code
 
     def check_complete(self, campaign):
-        # ... предыдущие условия
+        # ... previous conditions
         if "kill_enemy" in self.condition:
             killed = campaign.progress.get("enemies_killed", 0)
             return killed >= self.condition["kill_enemy"]["count"]

--- a/src/recipes.json
+++ b/src/recipes.json
@@ -1,21 +1,20 @@
 [
     {
-        "name": "Вода",
-        "ingredients": { "бутылка": 1 },
-        "result": "вода",
+        "name": "Water",
+        "ingredients": { "bottle": 1 },
+        "result": "water",
         "result_qty": 1
     },
     {
-        "name": "Еда",
-        "ingredients": { "ткань": 1, "ветка": 1 },
-        "result": "еда",
+        "name": "Food",
+        "ingredients": { "cloth": 1, "stick": 1 },
+        "result": "food",
         "result_qty": 1
     },
     {
-        "name": "Противоядие",
-        "ingredients": { "ткань": 1, "лекарство": 1 },
-        "result": "противоядие",
+        "name": "Antidote",
+        "ingredients": { "cloth": 1, "medicine": 1 },
+        "result": "antidote",
         "result_qty": 1
     }
-    // ... остальные рецепты
 ]

--- a/src/scenarios.json
+++ b/src/scenarios.json
@@ -1,24 +1,24 @@
 [
     {
         "id": "intro",
-        "name": "Введение",
-        "description": "Ознакомьтесь с основами выживания на этом поле.",
+        "name_key": "scenario_intro_name",
+        "desc_key": "scenario_intro_desc",
         "win_condition": {"survive_turns": 3},
         "lose_condition": {"player_dead": true},
         "next_scenario": "rescue"
     },
     {
         "id": "rescue",
-        "name": "Спасти выживших",
-        "description": "Найдите и спасите всех выживших на карте.",
+        "name_key": "scenario_rescue_name",
+        "desc_key": "scenario_rescue_desc",
         "win_condition": {"rescued": 3},
         "lose_condition": {"player_dead": true},
         "next_scenario": "finale"
     },
     {
         "id": "finale",
-        "name": "Последний бой",
-        "description": "Удержитесь от финальной волны врагов.",
+        "name_key": "scenario_finale_name",
+        "desc_key": "scenario_finale_desc",
         "win_condition": {"survive_turns": 5},
         "lose_condition": {"player_dead": true},
         "next_scenario": null

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,5 +1,6 @@
-# Небольшая утилита для цветного вывода в терминал (ANSI).
-# Простая обёртка — можно расширять для поддержки Windows (colorama) при необходимости.
+"""Utility functions for colored terminal output using ANSI codes."""
+
+# Simple wrapper – can be extended for Windows support (e.g. colorama) if needed.
 
 RESET = "\x1b[0m"
 BOLD = "\x1b[1m"
@@ -12,4 +13,10 @@ COLORS = {
     "blue": "\x1b[34m",
     "magenta": "\x1b[35m",
     "cyan": "\x1b[36m",
-    "white": "\x
+    "white": "\x1b[37m",
+}
+
+def color(text: str, color: str, bold: bool = False) -> str:
+    code = COLORS.get(color, "")
+    prefix = BOLD + code if bold else code
+    return f"{prefix}{text}{RESET}"

--- a/test_campaign_save_load.py
+++ b/test_campaign_save_load.py
@@ -12,7 +12,7 @@ from player import Player
 
 def test_campaign_can_be_saved_and_loaded(tmp_path):
     gm = GameMap(4, 4, player_pos=(1, 1))
-    inv = Inventory({"еда": 2}, coins=5)
+    inv = Inventory({"food": 2}, coins=5)
     player = Player(health=4, max_health=5)
     enemies = EnemyManager([Enemy((2, 2))])
 

--- a/test_inventory_items.py
+++ b/test_inventory_items.py
@@ -12,9 +12,9 @@ def test_use_food_water_and_antidote():
     camp = Campaign([])
     inv = camp.inventory
 
-    inv.add_item("еда", 1)
-    inv.add_item("вода", 1)
-    inv.add_item("противоядие", 1)
+    inv.add_item("food", 1)
+    inv.add_item("water", 1)
+    inv.add_item("antidote", 1)
 
     camp.status_effects = [
         StatusEffect("hunger", 2),
@@ -22,15 +22,15 @@ def test_use_food_water_and_antidote():
         StatusEffect("poison", 2),
     ]
 
-    inv.use_item("еда", camp)
-    assert not inv.has_item("еда")
+    inv.use_item("food", camp)
+    assert not inv.has_item("food")
     assert all(e.effect_type != "hunger" for e in camp.status_effects)
 
-    inv.use_item("вода", camp)
-    assert not inv.has_item("вода")
+    inv.use_item("water", camp)
+    assert not inv.has_item("water")
     assert all(e.effect_type != "thirst" for e in camp.status_effects)
 
-    inv.use_item("противоядие", camp)
-    assert not inv.has_item("противоядие")
+    inv.use_item("antidote", camp)
+    assert not inv.has_item("antidote")
     assert all(e.effect_type != "poison" for e in camp.status_effects)
 


### PR DESCRIPTION
## Summary
- add English locale entries for scenarios and events and reference them from scenario/event data
- translate inventory items, CLI messages, and campaign interactions to English
- clean up placeholder modules and comments for fully English codebase

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e53a314dc832985765a9e8af2f1be