### PR TITLE
Add balance data and survival item mechanics

### DIFF
--- a/src/enemies.py
+++ b/src/enemies.py
@@ -91,7 +91,14 @@ class EnemyManager:
 
     # factory -----------------------------------------------------------
     @staticmethod
-    def spawn_on_map(width: int, height: int, count: int, player_pos: Tuple[int, int]) -> "EnemyManager":
+    def spawn_on_map(
+        width: int,
+        height: int,
+        count: int,
+        player_pos: Tuple[int, int],
+        health: int = 3,
+        attack: int = 1,
+    ) -> "EnemyManager":
         """Spawn ``count`` enemies on random positions of the map."""
 
         positions = {player_pos}
@@ -100,7 +107,7 @@ class EnemyManager:
             x, y = random.randint(0, width - 1), random.randint(0, height - 1)
             if (x, y) in positions:
                 continue
-            enemies.append(Enemy((x, y)))
+            enemies.append(Enemy((x, y), health=health, attack=attack))
             positions.add((x, y))
         return EnemyManager(enemies)
 
@@ -114,8 +121,12 @@ class EnemyManager:
         """
 
         steps = 2 if campaign and getattr(campaign, "time_of_day", "day") == "night" else 1
+        target = player_pos
+        if campaign and getattr(campaign, "decoy_pos", None) is not None:
+            if any(e.effect_type == "decoy" for e in getattr(campaign, "status_effects", [])):
+                target = campaign.decoy_pos
         for enemy in self.enemies:
-            enemy.move_towards(player_pos, width, height, steps)
+            enemy.move_towards(target, width, height, steps)
 
     def get_enemy_at(self, pos: Tuple[int, int]) -> Optional[Enemy]:
         for enemy in self.enemies:

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Any
 
 from crafting import Recipe
+from enemies import StatusEffect
 
 
 @dataclass
@@ -81,6 +82,7 @@ class Inventory:
             campaign.status_effects = [
                 e for e in campaign.status_effects if e.effect_type != "hunger"
             ]
+            campaign.player.hunger = 0
             self.remove_item(item_name, 1)
             if len(campaign.status_effects) < before:
                 return "You ate and satisfied your hunger."
@@ -90,8 +92,20 @@ class Inventory:
             campaign.status_effects = [
                 e for e in campaign.status_effects if e.effect_type != "thirst"
             ]
+            campaign.player.thirst = 0
             self.remove_item(item_name, 1)
             return "You quenched your thirst."
+
+        if item_name == "armor":
+            campaign.player.armor = 2
+            self.remove_item(item_name, 1)
+            return "You equipped armor to reduce incoming damage."
+
+        if item_name == "decoy":
+            campaign.decoy_pos = (campaign.player.x, campaign.player.y)
+            campaign.status_effects.append(StatusEffect("decoy", duration=3))
+            self.remove_item(item_name, 1)
+            return "You placed a decoy to distract zombies."
 
         if item_name == "antidote":
             removed = False


### PR DESCRIPTION
## Summary
- load balance.json during campaign init to configure player and zombies
- introduce hunger/thirst counters with damage over time and rest reset
- extend inventory items for weapons, armor and decoys, and armour affects damage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f1932eeb48329a9f7a698f3385590