### PR TITLE
Implement scenario progression and final quest objectives

### DIFF
--- a/src/enemies.py
+++ b/src/enemies.py
@@ -127,6 +127,23 @@ class Enemy:
             return effect
         return None
 
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict:
+        return {
+            "pos": self.pos,
+            "health": self.health,
+            "attack": self.attack_damage,
+            "type": self.__class__.__name__,
+        }
+
+    @staticmethod
+    def from_dict(data: dict) -> "Enemy":
+        return Enemy(
+            tuple(data.get("pos", (0, 0))),
+            data.get("health", 3),
+            data.get("attack", 1),
+        )
+
 
 class FastZombie(Enemy):
     """Quick but fragile zombie that moves twice per turn."""

--- a/src/game_map.py
+++ b/src/game_map.py
@@ -29,6 +29,9 @@ class GameMap:
         self.width = width
         self.height = height
         self.player_pos = player_pos
+        # remember the starting tile so scenarios can reference it for
+        # objectives like "return to start"
+        self.start_pos = player_pos
         if visible is None:
             self.visible = [[False for _ in range(width)] for _ in range(height)]
         else:
@@ -65,6 +68,12 @@ class GameMap:
         new_x = max(0, min(self.width-1, x+dx))
         new_y = max(0, min(self.height-1, y+dy))
         self.player_pos = (new_x, new_y)
+        player = getattr(self, "player_entity", None)
+        if player is not None:
+            if hasattr(player, "set_position"):
+                player.set_position(new_x, new_y)
+            else:
+                player.x, player.y = new_x, new_y
         self.reveal(self.player_pos)
 
     def reveal(self, pos: Tuple[int, int]):

--- a/src/scenarios.json
+++ b/src/scenarios.json
@@ -19,8 +19,9 @@
         "id": "finale",
         "name_key": "scenario_finale_name",
         "desc_key": "scenario_finale_desc",
-        "win_condition": {"survive_turns": 5},
+        "win_condition": {"item": "antidote"},
         "lose_condition": {"player_dead": true},
+        "special_conditions": {"item_placement": [[2, 2, "A"]]},
         "next_scenario": null
-    }
+      }
 ]

--- a/test_scenario_progression_and_antidote.py
+++ b/test_scenario_progression_and_antidote.py
@@ -1,0 +1,62 @@
+from campaign import Campaign
+from scenario import Scenario
+from game_map import GameMap
+from inventory import Inventory
+from player import Player
+from enemies import EnemyManager
+
+
+def _dummy_campaign(scenarios):
+    gm = GameMap(4, 4, player_pos=(0, 0))
+    inv = Inventory()
+    player = Player(health=5, max_health=5)
+    enemies = EnemyManager([])
+    return Campaign(scenarios, game_map=gm, inventory=inv, player=player, enemies=enemies)
+
+
+def test_campaign_advances_after_survive_condition(capsys):
+    sc1 = Scenario("S1", "first", win_condition={"survive_turns": 1})
+    sc2 = Scenario("S2", "second", {})
+    camp = _dummy_campaign([sc1, sc2])
+    camp.start_next_scenario()
+    camp.turn_count = 1
+    camp.tick_time()
+    out = capsys.readouterr().out
+    assert "Scenario Complete" in out
+    assert camp.progress["current_index"] == 1
+
+
+def test_rescue_tracking_triggers_completion(capsys):
+    sc = Scenario("Rescue", "", win_condition={"rescued": 1})
+    camp = _dummy_campaign([sc, Scenario("Dummy", "", {})])
+    camp.start_next_scenario()
+    camp.rescue_survivor()
+    camp.turn_count += 1
+    camp.tick_time()
+    out = capsys.readouterr().out
+    assert "Scenario Complete" in out
+    assert camp.progress["current_index"] == 1
+
+
+def test_antidote_requires_return_to_start(capsys):
+    sc = Scenario(
+        "Finale",
+        "",
+        win_condition={"item": "antidote"},
+        special_conditions={"item_placement": [(1, 0, "A")]},
+    )
+    camp = _dummy_campaign([sc])
+    camp.start_next_scenario()
+    # move to antidote
+    camp.game_map.move_player(1, 0)
+    camp.turn_count += 1
+    camp.tick_time()
+    assert camp.inventory.has_item("antidote")
+    # not yet complete until back at start
+    assert camp.progress["current_index"] == 0
+    camp.game_map.move_player(-1, 0)
+    camp.turn_count += 1
+    camp.tick_time()
+    out = capsys.readouterr().out
+    assert "Scenario Complete" in out
+    assert camp.progress["campaign_complete"]


### PR DESCRIPTION
## Summary
- Track rescued survivors and special item pickups within the campaign
- Support advanced win/lose checks including antidote-return quest
- Sync player state with map and inventory for objective evaluation
- Add tests covering scenario progression and antidote finale

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5fbc590083298ac4db634c4c624e